### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/speedyk-005/chunklet-py/security/code-scanning/5](https://github.com/speedyk-005/chunklet-py/security/code-scanning/5)

Add an explicit `permissions` block in `.github/workflows/format.yml` at the workflow root so it applies to all jobs (including `lint`) unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read`

This preserves existing functionality (checkout + linting) while constraining token scope and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
