### PR TITLE
Fix duplicate line in split oversized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Visualizer**: Added `<label for="fileInput">` for screen-reader accessibility.
+- **Code chunker**: Fixed duplicate function signature in `_split_oversized` when a decorator precedes a class.
 
 ### Removed
 - **Dependencies**: `pysbd`, `sentsplit`, and `tabulate2`.

--- a/src/chunklet/code_chunker/code_chunker.py
+++ b/src/chunklet/code_chunker/code_chunker.py
@@ -205,7 +205,7 @@ class CodeChunker(BaseChunker):
                         }
                     )
                 )
-                curr_chunk = [line]  # Add the overflow line!
+                curr_chunk = []
                 token_count = 0
                 line_count = 0
 


### PR DESCRIPTION
Fix duplicate line in _split_oversized when a decorated class exceeds limits

When a class with a decorator (e.g. `@dataclass`) exceeded the token/line limit and strict=False, the first function signature was duplicated in the output. Root cause: the overflow line was added to curr_chunk twice — once during the reset and once at the bottom of the loop.
Fix is a one-line change: `curr_chunk = [line]` to `curr_chunk = []`
