### PR TITLE
Update documentation for 2.4.0 release and installation notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Code chunker**: Extracted `_handle_oversized_snippet` from `_group_by_chunk`.
 - **PPTX processor**: Simplified `_extract_text` (extracted `_is_template_placeholder` helper). Split `_extract_chart` into `_safe_chart_title` and `_plot_to_table`, now uses `build_md_table`.
 - **CLI split output**: Shows detected language code instead of raw `--lang` flag.
+- **Span finder**: Used walrus operator and dropped redundant `in`-check.
 
 ### Fixed
 - **Visualizer**: Added `<label for="fileInput">` for screen-reader accessibility.
+- **Sentence terminators**: Removed inverted punct (`¡`, `¿`) from global sentence terminators. They're opening marks in Spanish, not closing marks.
 
 ### Removed
 - **Dependencies**: `pysbd`, `sentsplit`, and `tabulate2`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,13 +21,14 @@ Hey! Thanks for thinking about contributing. Bug fixes, features, docs — all w
 
 > [!WARNING]
 > #### Termux (Android)
-> Termux doesn't have a rust toolchain by default, so pydantic-core might fail to build (especially for python 3.13).
-> Install pre-built wheels:
+> Termux doesn't have a rust toolchain by default, so pydantic-core and cryptography won't build from source.
+> Install pre-built wheels and dependencies:
 > 
 > ```bash
 > pip install typing-extensions
 > pip install pydantic-core --index-url https://termux-user-repository.github.io/pypi/
 > pip install "pydantic>=2.12.4,<2.13"
+> pkg install python-cryptography
 > pip install -e ".[dev-all]"
 > ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Dumb splitting causes problems:
 Smart chunking solves this by:
 
 - **Smart limits** — Respects both natural boundaries (sentences, paragraphs, sections) AND configurable limits (tokens, lines, functions)
-- **Language-aware** — Detects language automatically and applies the right rules (50+ languages supported)
+- **Language-aware** — Detects language automatically and applies the right rules (60+ languages supported)
 - **Context preservation** — Overlap between chunks, rich metadata (source, span, document structure)
 
 ## 🤔 So What's Chunklet-py Anyway? (And Why Should You Care?)
@@ -73,7 +73,7 @@ Perfect for prepping data for LLMs, building RAG systems, or powering AI search 
 | 🪶 **Featherlight Footprint** | Designed to be lightweight and memory-efficient, ensuring optimal performance without unnecessary overhead. |
 | 🗂️ **Rich Metadata for RAG** | Enriches chunks with valuable, context-aware metadata (source, span, document properties, code AST details) crucial for advanced RAG and LLM applications. |
 | 🔧 **Infinitely Customizable** | Offers extensive customization options, from pluggable token counters to custom sentence splitters and processors. |
-| 🌐 **Multilingual Mastery** | Supports over 50 natural languages for text and document chunking with intelligent detection and language-specific algorithms. |
+| 🌐 **Multilingual Mastery** | Supports over 60 natural languages for text and document chunking with intelligent detection and language-specific algorithms. |
 | 🧑‍💻 **Code-Aware Intelligence** | Language-agnostic code chunking that understands and preserves the structural integrity of your source code. |
 | 🎯 **Precision Chunking** | Flexible chunking with configurable limits based on sentences, tokens, sections, lines, and functions. |
 | 📄 **Document Format Mastery** | Processes a wide array of document formats including `.pdf`, `.docx`, `.epub`, `.txt`, `.tex`, `.html`, `.hml`, `.md`, `.rst`, `.rtf`, `.odt`, `.csv`, and `.xlsx`. |

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Want to unlock more Chunklet-py superpowers? Add these optional dependencies bas
 *   **Visualization:** For the interactive web-based chunk visualizer:
     ```bash
     pip install "chunklet-py[visualization]"
+    # Or
+    pip install "chunklet-py[viz]"
     ```
 * **All Extras:** To install all optional dependencies:
     ```bash

--- a/README.md
+++ b/README.md
@@ -271,6 +271,13 @@ splitter = SentenceSplitter()
 sentences = splitter.split_text(text, lang="auto")
 ```
 
+> [!TIP]
+> **Advanced text splitting**
+>
+> Chunklet-py quietly delegates sentence splitting to [yasbd-lib](https://github.com/speedyk-005/yasbd-lib), our high-accuracy SBD supporting **39 languages**.
+>
+> Curious why we built it? Read **[yasbd-lib vs PySBD: Two Philosophies of Sentence Boundary Detection](https://dev.to/speed_k_7e1b449706e59e433/yasbd-lib-vs-pysbd-two-philosophies-of-sentence-boundary-detection-i88)**.
+
 **CLI (Command Line Interface)**
 
 If you prefer the terminal to an IDE, the CLI is packed with features. Just ask for help.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The simplest way to get started is with pip:
 
 ```bash
 # Install and check it's working
-pip install chunklet-py
+pip install chunklet-py -U
 chunklet --version
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,12 +107,14 @@ chunklet --version
 > [!TIP]
 > <b>Termux (Android)</b>
 >
-> No rust toolchain on Termux (especially python 3.13)? Install pydantic-core pre-built wheels first then retry installing chunklet-py:
+> No rust toolchain on Termux (especially python 3.13)? Pydantic-core and cryptography won't build from source.
+> Install pre-built wheels and dependencies:
 >
 > ```bash
 > pip install typing-extensions
 > pip install pydantic-core --index-url https://termux-user-repository.github.io/pypi/
 > pip install "pydantic>=2.12.4,<2.13"
+> pkg install python-cryptography
 > ```
 
 That's it! You're all set to start chunking.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,7 +14,7 @@ The most straightforward method to install Chunklet-py is by using `pip`:
 
 ```bash
 # Install and verify version
-pip install chunklet-py
+pip install chunklet-py -U
 chunklet --version
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -44,6 +44,8 @@ Chunklet-py offers optional dependencies to unlock additional functionalities, s
 *   **Visualization:** For the interactive web-based chunk visualizer:
     ```bash
     pip install "chunklet-py[visualization]"
+    # Or
+    pip install "chunklet-py[viz]"
     ```
 *   **All Extras:** To install all optional dependencies:
     ```bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,12 +19,14 @@ chunklet --version
 ```
 
 !!! tip "Termux (Android)"
-    No rust toolchain on Termux (especially python 3.13)? Install pydantic-core pre-built wheels first then retry installing chunklet-py:
+    No rust toolchain on Termux (especially python 3.13)? Pydantic-core and cryptography won't build from source.
+    Install pre-built wheels and dependencies:
     
     ```bash
     pip install typing-extensions
     pip install pydantic-core --index-url https://termux-user-repository.github.io/pypi/
     pip install "pydantic>=2.12.4,<2.13"
+    pkg install python-cryptography
     ```
 
 And that's all there is to it! You're now ready to start using Chunklet-py.

--- a/docs/getting-started/programmatic/document_chunker.md
+++ b/docs/getting-started/programmatic/document_chunker.md
@@ -32,7 +32,7 @@ The `DocumentChunker` comes packed with smart features that make it your go-to t
 
 -  **Flexible Composable Constraints:** Ultimate control over your chunks! Mix and match limits based on sentences, tokens, or section breaks (headings, horizontal rules, `<details>` tags). Craft exactly the chunk size you need with precision control! 🎯
 -  **Intelligent Overlap:** Adds smart overlaps between chunks so your text flows smoothly. No more jarring transitions that leave readers scratching their heads!
--  **Extensive Multilingual Support:** Speaks over 50 languages fluently, thanks to our trusty sentence splitter. Global domination through better text chunking! 🌍
+-  **Extensive Multilingual Support:** Speaks over 60 languages fluently, thanks to our trusty sentence splitter. Global domination through better text chunking! 🌍
 -  **Customizable Token Counting:** Plug in your own token counter for perfect alignment with different LLMs. Because one size definitely doesn't fit all models!
 -  **Memory-Conscious Operation:** Handles massive documents efficiently by yielding chunks one at a time. Your RAM will thank you later! 💾
 -  **Multi-Format Maestro:** From corporate DOCX boardrooms to academic PDF libraries, this chunker speaks every file language fluently! Handles `.pdf`, `.docx`, `.epub`, `.eml`, `.pptx`, `.txt`, `.tex`, `.html`, `.hml`, `.md`, `.rst`, `.rtf`, `.odt`, `.csv`, and `.xlsx` files like a pro. 🌍

--- a/docs/getting-started/programmatic/document_chunker.md
+++ b/docs/getting-started/programmatic/document_chunker.md
@@ -7,7 +7,7 @@
 ## Quick Install
 
 ```bash
-pip install chunklet-py
+pip install chunklet-py -U
 ```
 
 No extra dependencies needed - `DocumentChunker` is ready to roll right out of the box for plain text! 🚀

--- a/docs/getting-started/programmatic/index.md
+++ b/docs/getting-started/programmatic/index.md
@@ -6,7 +6,7 @@ Welcome to the programmatic interface! This is where you integrate Chunklet-py's
 
     ---
 
-    Precisely splits text into semantically meaningful sentences across 50+ languages with intelligent detection and complex structure handling.
+    Precisely splits text into semantically meaningful sentences across 60+ languages with intelligent detection and complex structure handling.
 
     Essential for preparing clean text data for NLP tasks, LLMs, and any application that needs accurate sentence boundaries.
 

--- a/docs/getting-started/programmatic/sentence_splitter.md
+++ b/docs/getting-started/programmatic/sentence_splitter.md
@@ -10,13 +10,13 @@ Splitting text by periods is like trying to perform surgery with a butter knife 
 
 This problem has a name: [Sentence Boundary Disambiguation](https://en.wikipedia.org/wiki/Sentence_boundary_disambiguation). That's where `SentenceSplitter` comes in.
 
-Think of it as a skilled linguist who knows where sentences actually end. It handles grammar, context, and those tricky abbreviations (like "Dr." or "U.S.A.") without breaking a sweat. Supports 50+ languages out of the box.
+Think of it as a skilled linguist who knows where sentences actually end. It handles grammar, context, and those tricky abbreviations (like "Dr." or "U.S.A.") without breaking a sweat. Supports 60+ languages out of the box.
 
 ### What's Under the Hood? ⚙️
 
 The `SentenceSplitter` is a sophisticated system:
 
--  **Multilingual Support 🌍:** Handles over **50** languages with intelligent detection. See the [full list](../../supported-languages.md).
+-  **Multilingual Support 🌍:** Handles over **60** languages with intelligent detection. See the [full list](../../supported-languages.md).
 -  **Custom Splitters 🔧:** Plug in your own splitting logic for specialized languages or domains.
 -  **Reliable Fallback 🛡️:** For unsupported languages, a rule-based fallback kicks in.
 -  **Error Monitoring 🔍:** Reports issues with custom splitters clearly.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Dumb splitting causes problems:
 Smart chunking solves this by:
 
 - **Smart limits** — Respects both natural boundaries (sentences, paragraphs, sections) AND configurable limits (tokens, lines, functions)
-- **Language-aware** — Detects language automatically and applies the right rules (50+ languages supported)
+- **Language-aware** — Detects language automatically and applies the right rules (60+ languages supported)
 - **Context preservation** — Overlap between chunks, rich metadata (source, span, document structure)
 
 ## 🤔 So What's Chunklet-py Anyway? (And Why Should You Care?)
@@ -66,7 +66,7 @@ Perfect for prepping data for LLMs, building RAG systems, or powering AI search 
 
 - :material-translate:{ .lg .middle } __Multilingual Mastery__
 
-    Supports over 50 natural languages for text and document chunking with intelligent detection and language-specific algorithms.
+    Supports over 60 natural languages for text and document chunking with intelligent detection and language-specific algorithms.
 
 - :material-code-tags:{ .lg .middle } __Code-Aware Intelligence__
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -3,7 +3,35 @@
 
 ---
 
+## Chunklet v2.4.0
+
+### 📎 EML and PPTX, At Your Service
+
+Two new processors joined the family. EML (RFC 822 email) and PPTX (PowerPoint). Drop a `.eml` or `.pptx` in, get chunks out. Nothing to configure, nothing to wire up.
+
+The EML one grabs body, subject, headers, and attachments. The PPTX one handles slides, tables, charts, and presenter notes. We also built a shared `build_md_table()` utility so CSV, XLSX, and PPTX tables all go through the same code path instead of three different ones.
+
+### 🇺🇳 yasbd-lib: Faster, More accurate, More Languages
+
+We swapped `pysbd` and `sentsplit` for [`yasbd-lib`](https://github.com/speedyk-005/yasbd-lib). Total supported languages went from 53 to 62. 39 built-in in yasbd-lib alone plus fallbacks for the rest. Not convinced? Then let [yasbd-lib vs PySBD](https://dev.to/speed_k_7e1b449706e59e433/yasbd-lib-vs-pysbd-two-philosophies-of-sentence-boundary-detection-i88) prove it.
+
+### 🐛 What Broke and Got Fixed
+
+- **Visualizer label**: `<label for="fileInput">` so screen readers can actually see the file picker
+- **Lazy import gotcha**: `if not epub:` became `if epub is None:` because truthiness on an optional import is not a personality trait
+- **Split oversize dupe**: `_split_oversized` no longer doubles the first function signature when a decorated class hits the limit. `curr_chunk = [line]` + `curr_chunk.append(line)` is one too many.
+- **Bye dependencies**: dropped `pysbd`, `sentsplit`, and `tabulate2`
+
+### 🧹 The Little Things
+
+- **CLI split output**: shows the detected language instead of `--lang=en --lang=en` (yes, it was literally showing the flag in the output)
+- **Sentence terminators**: removed `¡` and `¿`. They're Spanish opening marks, not sentence closers. We didn't notice for a while. Spanish speakers probably did.
+- **Code chunker cleanup**: extracted `_handle_oversized_snippet` with `**kwargs` so we don't have to thread params through the main loop every time we sneeze
+
+---
+
 ## Chunklet v2.3.2
+
 
 ### 🏎️ DotDict Gets Box-Compatible Serialization
 

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,3 @@
+Improve code cleanup throughout the codebase
+
+Extracted `_handle_oversized_snippet` from the main loop in `_group_by_chunk`. Simplified `_extract_text` and split `_extract_chart` in the PPTX processor into smaller helpers. CLI split output now shows the detected language code instead of the raw `--lang` flag. Added `<label>` to the visualizer file input for accessibility. Full `ruff format && ruff check --fix` pass. Changelog updated.

--- a/pr.md
+++ b/pr.md
@@ -1,3 +1,0 @@
-Improve code cleanup throughout the codebase
-
-Extracted `_handle_oversized_snippet` from the main loop in `_group_by_chunk`. Simplified `_extract_text` and split `_extract_chart` in the PPTX processor into smaller helpers. CLI split output now shows the detected language code instead of the raw `--lang` flag. Added `<label>` to the visualizer file input for accessibility. Full `ruff format && ruff check --fix` pass. Changelog updated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ classifiers = [
 ]
 
 keywords = [
-  "nlp", "chunking", "text-splitting", "sentence-splitting", "llm", "rag", "ai", "multilingual",
+  "nlp", "chunking", "chunker", "text-chunking", "text-splitting", "sentence-splitting", "llm", "rag", "ai", "multilingual",
   "text processing", "natural language processing", "data processing",
   "information retrieval", "semantic search", "document processing", "document-chunker",
-  "code chunking", "code-chunker", "source code analysis", "programming languages",
+  "code chunking", "code-chunker", "programming languages",
   "code structure", "chunk-visualization",
 ]
 


### PR DESCRIPTION
Docs updates: language count bump, yasbd note, whats-new 2.4.0

- Bump language count from 50+ to 60+ across README and docs
- Add yasbd-lib TIP note with repo and blog link in README
- Add 2.4.0 release highlights to whats-new
- Use -U flag in pip install examples
- Add termux cryptography install notes
- Mention viz shortcut for visualization extra
- Update keywords in pyproject.toml
