### PR TITLE
fix: collect all EML metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.4.2] - 2026-07-29
+
+### Fixed
+- **EML processor**: Fixed metadata extraction to capture all header fields (subject, from, to, cc, date) instead of only the body. Thanks [@AkshatSharma25](https://github.com/AkshatSharma25).
+
+---
+
 ## [2.4.0] - 2026-07-27
 
 ### Added
@@ -28,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - **Dependencies**: `pysbd`, `sentsplit`, and `tabulate2`.
+
+---
+
+## [2.4.1] - 2026-07-29
+
+### Fixed
+- **EML processor**: Fixed metadata extraction to capture all header fields (subject, from, to, cc, date) instead of only the body. Thanks [@AkshatSharma25](https://github.com/AkshatSharma25).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ A huge thank you to the awesome people who helped shape Chunklet-py:
 
 - [@jmbernabotto](https://github.com/jmbernabotto) — for helping mostly on the CLI part, suggesting fixes, features, and design improvements.
 - [@arnoldfranz](https://github.com/arnoldfranz) — for reporting the CLI Path Validation Bug (#6) that helped improve error handling.
+- [@AkshatSharma25](https://github.com/AkshatSharma25) — for fixing EML metadata extraction to capture all header fields.
 
 ---
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -3,6 +3,18 @@
 
 ---
 
+## Chunklet v2.4.1 and v2.4.2
+
+### 📄 The "We Forgot to Mention" Release
+
+- README now lists EML and PPTX in supported formats (they were there, just hiding)
+
+### 🐛 EML Metadata, Actually Complete
+
+PR from [@AkshatSharma25](https://github.com/AkshatSharma25) — the EML processor was quietly dropping header fields (subject, from, to, cc, date) and only grabbing the body. Fixed. All fields captured now.
+
+---
+
 ## Chunklet v2.4.0
 
 ### 📎 EML and PPTX, At Your Service

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chunklet-py"
-version = "2.4.1"
+version = "2.4.2"
 description = "High-fidelity context-aware chunking and interactive visualization for RAG. Advanced segmentation for code and documents, because your LLM is only as smart as the fragments you feed it."
 authors = [
   { name = "speedyk_005", email = "speedy40115719@gmail.com" }

--- a/src/chunklet/document_chunker/processors/eml_processor.py
+++ b/src/chunklet/document_chunker/processors/eml_processor.py
@@ -84,7 +84,7 @@ class EmlProcessor(BaseProcessor):
             if val := self._parsed.get(field):
                 metadata[field] = val
 
-            return metadata
+        return metadata
 
     def extract_text(self) -> Generator[str, None, None]:
         """

--- a/tests/test_eml_processor.py
+++ b/tests/test_eml_processor.py
@@ -1,0 +1,24 @@
+from chunklet.document_chunker.processors.eml_processor import EmlProcessor
+
+
+def test_extract_metadata_returns_all_available_fields():
+    processor = EmlProcessor.__new__(EmlProcessor)
+    processor.file_path = "sample.eml"
+    processor._parsed = {
+        "subject": "Project update",
+        "from": "alice@example.com",
+        "to": ["bob@example.com"],
+        "message_id": "<message@example.com>",
+        "attachment": [{"name": "report.pdf"}],
+        "inline": [{"name": "logo.png"}],
+    }
+
+    assert processor.extract_metadata() == {
+        "source": "sample.eml",
+        "subject": "Project update",
+        "from": "alice@example.com",
+        "to": ["bob@example.com"],
+        "message_id": "<message@example.com>",
+        "attachment_names": ["report.pdf"],
+        "inline_names": ["logo.png"],
+    }


### PR DESCRIPTION
`EmlProcessor.extract_metadata()` returns during the first iteration of the metadata loop, so fields after subject are skipped.

This moves the return outside the loop and adds a regression test covering message headers, attachment names, and inline-file names.

Tested with:

`uv run pytest tests/test_eml_processor.py -q`
`uv run ruff check src/chunklet/document_chunker/processors/eml_processor.py tests/test_eml_processor.py`

Closes #56