### PR TITLE
Cleanup code across three files

### DIFF
--- a/audit_migration.py
+++ b/audit_migration.py
@@ -181,7 +181,9 @@ class MigrationAuditor:
                 "bold red",
             )
 
-    def _audit_calls(self, file_path: Path, tree: ast.AST, tracked_instances: set, lines: list[str]):
+    def _audit_calls(
+        self, file_path: Path, tree: ast.AST, tracked_instances: set, lines: list[str]
+    ):
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -198,9 +200,7 @@ class MigrationAuditor:
 
             if method_name in LEGACY_METHODS:
                 style = (
-                    "bold red"
-                    if method_name in ("preview_sentences",)
-                    else "yellow"
+                    "bold red" if method_name in ("preview_sentences",) else "yellow"
                 )
                 self._has_legacy_issues = True
                 self._print_issue(

--- a/examples/langchain_integration.py
+++ b/examples/langchain_integration.py
@@ -10,9 +10,9 @@ Run:
     python examples/langchain_integration.py
 """
 
-from chunklet import DocumentChunker
 from langchain_core.documents import Document  # pip install langchain-core
 
+from chunklet import DocumentChunker
 
 text = """
 Artificial intelligence (AI) is transforming industries worldwide.
@@ -31,13 +31,10 @@ The field has advanced rapidly with transformer architectures.
 chunker = DocumentChunker()
 chunks = chunker.chunk_text(text, max_sentences=2, overlap_percent=10)
 
-docs = [
-    Document(page_content=c.content, metadata=c.metadata)
-    for c in chunks
-]
+docs = [Document(page_content=c.content, metadata=c.metadata) for c in chunks]
 
 for i, doc in enumerate(docs):
-    print(f"--- Chunk {i+1} ---")
+    print(f"--- Chunk {i + 1} ---")
     print(doc.page_content)
     print(f"Metadata: {doc.metadata}")
     print()

--- a/src/chunklet/code_chunker/code_chunker.py
+++ b/src/chunklet/code_chunker/code_chunker.py
@@ -398,7 +398,9 @@ class CodeChunker(BaseChunker):
                 function_count + 1 > max_functions
             )
 
-            if not any([token_limit_reached, line_limit_reached, function_limit_reached]):
+            if not any(
+                [token_limit_reached, line_limit_reached, function_limit_reached]
+            ):
                 # Fits: merge normally
                 merged_content.append(snippet_dict["content"])
                 relations_list.append(snippet_dict["relations"])

--- a/src/chunklet/code_chunker/code_chunker.py
+++ b/src/chunklet/code_chunker/code_chunker.py
@@ -398,9 +398,7 @@ class CodeChunker(BaseChunker):
                 function_count + 1 > max_functions
             )
 
-            if not (
-                token_limit_reached or line_limit_reached or function_limit_reached
-            ):
+            if not any([token_limit_reached, line_limit_reached, function_limit_reached]):
                 # Fits: merge normally
                 merged_content.append(snippet_dict["content"])
                 relations_list.append(snippet_dict["relations"])

--- a/src/chunklet/document_chunker/_plain_text_chunker.py
+++ b/src/chunklet/document_chunker/_plain_text_chunker.py
@@ -322,11 +322,10 @@ class PlainTextChunker:
         while index < len(sentences):
             sentence = sentences[index]
 
+            is_heading = False
             if SECTION_BREAK_PATTERN.match(sentence):
                 is_heading = True
                 sentence = "\n" + sentence
-            else:
-                is_heading = False
 
             sentence_tokens = (
                 count_tokens(sentence + "\n", token_counter)
@@ -338,16 +337,16 @@ class PlainTextChunker:
                 constraint_counter["sentence_count"] + 1 > max_sentences
             )
             heading_limit_reached = (
-                is_heading
-                and constraint_counter["heading_count"] + 1 > max_section_breaks
+                is_heading and constraint_counter["heading_count"] + 1 > max_section_breaks
             )
             token_limit_reached = (
                 max_tokens != sys.maxsize
                 and constraint_counter["token_count"] + sentence_tokens > max_tokens
             )
 
-            if token_limit_reached or sentence_limit_reached or heading_limit_reached:
+            if any([token_limit_reached, sentence_limit_reached, heading_limit_reached]):
                 # for token-based mode, try splitting further
+                unfitted = ""
                 if token_limit_reached:
                     remaining_tokens = max_tokens - constraint_counter["token_count"]
                     fitted, unfitted = self._find_clauses_that_fit(
@@ -378,9 +377,6 @@ class PlainTextChunker:
                         # We need to process the remnants separately
                         sentences[index] = unfitted
 
-                else:
-                    unfitted = ""
-
                 chunks.append("\n".join(curr_chunk))  # Considered complete
 
                 curr_chunk = self._prepare_next_chunk(
@@ -393,13 +389,12 @@ class PlainTextChunker:
                     constraint_counter=constraint_counter,
                 )
 
-            else:
-                curr_chunk.append(sentence)
-                constraint_counter["token_count"] += sentence_tokens
-                constraint_counter["sentence_count"] += 1
-                if is_heading:
-                    constraint_counter["heading_count"] += 1
-                index += 1
+            curr_chunk.append(sentence)
+            constraint_counter["token_count"] += sentence_tokens
+            constraint_counter["sentence_count"] += 1
+            if is_heading:
+                constraint_counter["heading_count"] += 1
+            index += 1
 
         # Add the last chunk if it exists
         if curr_chunk:

--- a/src/chunklet/document_chunker/_plain_text_chunker.py
+++ b/src/chunklet/document_chunker/_plain_text_chunker.py
@@ -337,14 +337,17 @@ class PlainTextChunker:
                 constraint_counter["sentence_count"] + 1 > max_sentences
             )
             heading_limit_reached = (
-                is_heading and constraint_counter["heading_count"] + 1 > max_section_breaks
+                is_heading
+                and constraint_counter["heading_count"] + 1 > max_section_breaks
             )
             token_limit_reached = (
                 max_tokens != sys.maxsize
                 and constraint_counter["token_count"] + sentence_tokens > max_tokens
             )
 
-            if any([token_limit_reached, sentence_limit_reached, heading_limit_reached]):
+            if any(
+                [token_limit_reached, sentence_limit_reached, heading_limit_reached]
+            ):
                 # for token-based mode, try splitting further
                 unfitted = ""
                 if token_limit_reached:

--- a/src/chunklet/document_chunker/processors/pptx_processor.py
+++ b/src/chunklet/document_chunker/processors/pptx_processor.py
@@ -180,15 +180,11 @@ class PPTXProcessor(BaseProcessor):
     @staticmethod
     def _plot_to_table(plot: Any) -> list[list[str]] | None:
         """Build a list-of-lists table (header + rows) from a chart plot."""
-        categories = getattr(plot, "categories", None)
-        if not categories:
+        if not (categories := getattr(plot, "categories", None)):
             return None
-        try:
-            categories = [str(c) for c in categories]
-        except (TypeError, ValueError):
-            return None
+        categories = [str(c) for c in categories]
 
-        series_list = list(getattr(plot, "series", []) or [])
+        series_list = getattr(plot, "series", [])
         if not series_list:
             return None
 

--- a/src/chunklet/document_chunker/processors/pptx_processor.py
+++ b/src/chunklet/document_chunker/processors/pptx_processor.py
@@ -270,40 +270,25 @@ class PPTXProcessor(BaseProcessor):
         for slide_idx, slide in enumerate(self.prs.slides, start=1):
             slide_content = [f"\n<!-- Slide {slide_idx} -->\n"]
 
-            # 1. Title Processing
-            title = self._extract_slide_title(slide)
-            if title:
+            # Title
+            if title := self._extract_slide_title(slide):
                 slide_content.append(title)
 
-            # 2. Iterate remaining layout blocks
+            # Layout blocks
             for shape in slide.shapes:
                 if shape == slide.shapes.title:
                     continue
+                if table_md := self._extract_table(shape):
+                    slide_content.append(table_md)
+                if chart_md := self._extract_chart(shape):
+                    slide_content.append(chart_md)
+                if text_md := self._extract_text(shape):
+                    slide_content.append(text_md)
 
-                # Handle Table blocks
-                if hasattr(shape, "has_table") and shape.has_table:
-                    table_md = self._extract_table(shape)
-                    if table_md:
-                        slide_content.append(table_md)
-
-                # Handle Chart blocks
-                elif hasattr(shape, "has_chart") and shape.has_chart:
-                    chart_md = self._extract_chart(shape)
-                    if chart_md:
-                        slide_content.append(chart_md)
-
-                # Handle text boxes & paragraphs
-                elif hasattr(shape, "has_text_frame") and shape.has_text_frame:
-                    text_md = self._extract_text(shape)
-                    if text_md:
-                        slide_content.append(text_md)
-
-            # 3. Presenter Notes Append
-            notes_md = self._extract_notes(slide)
-            if notes_md:
+            # Presenter Notes
+            if notes_md := self._extract_notes(slide):
                 slide_content.append(notes_md)
 
-            # Package slide buffer string cleanly
             yield "\n".join(slide_content).strip()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "chunklet-py"
-version = "2.4.0"
+version = "2.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
Cleans up code across three files:

- Use `any()` instead of chained `or` for limit checks in code and plain text chunkers
- Simplify `_plot_to_table` with walrus operator and remove redundant try/except
- Reduce cognitive complexity in `extract_text` by relying on self-guarding extract methods
- Run `ruff format` across affected files