### PR TITLE
Move chunking constraints from per-call args to constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Plain text chunker**: When a sentence is split mid-way on the token limit, its unfitted remainder now opens the next chunk instead of the full sentence being re-appended on top of the overlap clause. Fixes duplicated clauses and unresolved `(-1, -1)` spans in token-limited chunking.
 - **Span finder**: The normalized search keeps `#` from Markdown headings, so a chunk starting with a heading reports a span that includes the heading marker instead of starting after it.
 
+### Changed
+- **Chunker constraints moved to the constructor**: Sizing/tuning parameters are now set at `__init__` instead of per call:
+  - `DocumentChunker` / `PlainTextChunker`: `max_tokens`, `max_sentences`, `max_section_breaks`, `overlap_percent`, `offset`, and `lang` are now set at construction instead of passed to `chunk_text` / `chunk_texts` / `chunk_file` / `chunk_files`.
+  - `CodeChunker`: `max_tokens`, `max_lines`, and `max_functions` are now set at construction. `strict`, `docstring_mode`, and `include_comments` remain per-call.
+  - `SentenceSplitter`: `lang` is now set at construction; `split_text` / `split_file` no longer accept it.
+- **Mutability**: Constraints are now plain attributes on the chunker. Mutating a validated constraint (e.g., `chunker.max_sentences = 4`) re-runs constraint validation, and `DocumentChunker` delegates these attributes to its internal plain-text chunker.
+
 ### Removed
 - **Deprecated APIs**: Removed the aliases deprecated in v2.2.0 ahead of the v3.0.0 release:
   - `chunk()` and `batch_chunk()` from `DocumentChunker` and `CodeChunker`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Plain text chunker**: When a sentence is split mid-way on the token limit, its unfitted remainder now opens the next chunk instead of the full sentence being re-appended on top of the overlap clause. Fixes duplicated clauses and unresolved `(-1, -1)` spans in token-limited chunking.
 - **Span finder**: The normalized search keeps `#` from Markdown headings, so a chunk starting with a heading reports a span that includes the heading marker instead of starting after it.
 
-### Changed
-- **Chunker constraints moved to the constructor**: Sizing/tuning parameters are now set at `__init__` instead of per call:
-  - `DocumentChunker` / `PlainTextChunker`: `max_tokens`, `max_sentences`, `max_section_breaks`, `overlap_percent`, `offset`, and `lang` are now set at construction instead of passed to `chunk_text` / `chunk_texts` / `chunk_file` / `chunk_files`.
-  - `CodeChunker`: `max_tokens`, `max_lines`, and `max_functions` are now set at construction. `strict`, `docstring_mode`, and `include_comments` remain per-call.
-  - `SentenceSplitter`: `lang` is now set at construction; `split_text` / `split_file` no longer accept it.
-- **Mutability**: Constraints are now plain attributes on the chunker. Mutating a validated constraint (e.g., `chunker.max_sentences = 4`) re-runs constraint validation, and `DocumentChunker` delegates these attributes to its internal plain-text chunker.
-
 ### Removed
 - **Deprecated APIs**: Removed the aliases deprecated in v2.2.0 ahead of the v3.0.0 release:
   - `chunk()` and `batch_chunk()` from `DocumentChunker` and `CodeChunker`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,10 @@ Order methods like this:
 1. Class docstring
 2. Constants/attributes
 3. `__init__`
-4. Properties (`@property`)
-5. Private methods (`_method`)
-6. Public methods (`method`)
+4. Dunder methods (`__getattr__`, `__setattr__`, etc.)
+5. Properties (`@property`)
+6. Private methods (`_method`)
+7. Public methods (`method`)
 
 ```python
 class ExampleClass:
@@ -79,6 +80,9 @@ class ExampleClass:
     CONSTANT = "value"
 
     def __init__(self):
+        pass
+
+    def __getattr__(self, name):
         pass
 
     @property

--- a/src/chunklet/cli.py
+++ b/src/chunklet/cli.py
@@ -308,15 +308,15 @@ def split_command(
         raise typer.Exit(code=1)
 
     # Split Logic
-    splitter = SentenceSplitter(verbose=verbose)
+    splitter = SentenceSplitter(lang=lang or "auto", verbose=verbose)
 
     if source:
-        sentences = splitter.split_file(source, lang=lang or "auto")
+        sentences = splitter.split_file(source)
         lang_detected, confidence = splitter.detected_top_language(
             source.read_text(encoding="utf-8")
         )
     else:
-        sentences = splitter.split_text(input_text, lang=lang or "auto")
+        sentences = splitter.split_text(input_text)
         lang_detected, confidence = splitter.detected_top_language(input_text)
 
     # Output Handling
@@ -533,10 +533,10 @@ def chunk_command(
             max_section_breaks=max_section_breaks,
             overlap_percent=overlap_percent,
             offset=offset,
+            lang=lang,
         )
         chunk_kwargs = {
             "token_counter": token_counter,
-            "lang": lang,
         }
 
     # --- Chunking logic ---

--- a/src/chunklet/cli.py
+++ b/src/chunklet/cli.py
@@ -494,12 +494,6 @@ def chunk_command(
     if tokenizer_command:
         token_counter = _create_external_tokenizer(tokenizer_command, tokenizer_timeout)
 
-    # Construct chunk_kwargs dynamically
-    chunk_kwargs = {
-        "max_tokens": max_tokens,
-        "token_counter": token_counter,
-    }
-
     if code:
         if CodeChunker is None:
             typer.echo(
@@ -512,16 +506,16 @@ def chunk_command(
         chunker_instance = CodeChunker(
             verbose=verbose,
             token_counter=token_counter,
+            max_tokens=max_tokens,
+            max_lines=max_lines,
+            max_functions=max_functions,
         )
-        chunk_kwargs.update(
-            {
-                "max_lines": max_lines,
-                "max_functions": max_functions,
-                "docstring_mode": docstring_mode,
-                "strict": strict,
-                "include_comments": include_comments,
-            }
-        )
+        chunk_kwargs = {
+            "token_counter": token_counter,
+            "docstring_mode": docstring_mode,
+            "strict": strict,
+            "include_comments": include_comments,
+        }
     else:
         if DocumentChunker is None:
             typer.echo(
@@ -534,16 +528,16 @@ def chunk_command(
         chunker_instance = DocumentChunker(
             verbose=verbose,
             token_counter=token_counter,
+            max_tokens=max_tokens,
+            max_sentences=max_sentences,
+            max_section_breaks=max_section_breaks,
+            overlap_percent=overlap_percent,
+            offset=offset,
         )
-        chunk_kwargs.update(
-            {
-                "lang": lang,
-                "max_sentences": max_sentences,
-                "max_section_breaks": max_section_breaks,
-                "overlap_percent": overlap_percent,
-                "offset": offset,
-            }
-        )
+        chunk_kwargs = {
+            "token_counter": token_counter,
+            "lang": lang,
+        }
 
     # --- Chunking logic ---
     if text:

--- a/src/chunklet/code_chunker/code_chunker.py
+++ b/src/chunklet/code_chunker/code_chunker.py
@@ -79,20 +79,38 @@ class CodeChunker(BaseChunker):
     @validate_input
     def __init__(
         self,
-        verbose: bool = False,
+        max_tokens: Annotated[int | None, Field(ge=12)] = None,
+        max_lines: Annotated[int | None, Field(ge=5)] = None,
+        max_functions: Annotated[int | None, Field(ge=1)] = None,
         token_counter: Callable[[str], int] | None = None,
+        verbose: bool = False,
     ):
         """
-        Initialize the CodeChunker with optional token counter and verbosity control.
+        Initialize the CodeChunker with optional constraints, token counter,
+        and verbosity control.
 
         Args:
+            max_tokens: Maximum tokens per chunk. Must be >= 12.
+            max_lines: Maximum number of lines per chunk. Must be >= 5.
+            max_functions: Maximum number of functions per chunk. Must be >= 1.
+            token_counter: Function that counts tokens in text. Required for
+                token-based chunking. If None, must be provided when calling
+                chunk methods.
             verbose: Enable verbose logging.
-            token_counter: Function that counts tokens in text.
-                If None, must be provided when calling chunk() methods.
         """
         self.token_counter = token_counter
         self._verbose = verbose
+        self.max_tokens = max_tokens
+        self.max_lines = max_lines
+        self.max_functions = max_functions
         self.extractor = CodeStructureExtractor(verbose=self._verbose)
+
+        self._validate_constraints(
+            max_tokens=max_tokens,
+            max_lines=max_lines,
+            max_functions=max_functions,
+            token_counter=token_counter,
+        )
 
     @property
     def verbose(self) -> bool:
@@ -515,9 +533,6 @@ class CodeChunker(BaseChunker):
         self,
         code: str,
         *,
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_lines: Annotated[int | None, Field(ge=5)] = None,
-        max_functions: Annotated[int | None, Field(ge=1)] = None,
         token_counter: Callable[[str], int] | None = None,
         include_comments: bool = True,
         docstring_mode: Literal["summary", "all", "excluded"] = "all",
@@ -526,14 +541,11 @@ class CodeChunker(BaseChunker):
         """
         Extract semantic code chunks from source using multi-dimensional analysis.
         Processes source code by identifying structural boundaries (functions, classes,
-        namespaces) and grouping content based on multiple constraints including
-        tokens, lines, and logical units while preserving semantic coherence.
+        namespaces) and grouping content based on multiple constraints that are
+        configured at initialization while preserving semantic coherence.
 
         Args:
             code: Raw code string or file path to process.
-            max_tokens: Maximum tokens per chunk. Must be >= 12.
-            max_lines: Maximum number of lines per chunk. Must be >= 5.
-            max_functions: Maximum number of functions per chunk. Must be >= 1.
             token_counter: Token counting function. Uses instance
                 counter if None. Required for token-based chunking.
             include_comments: Include comments in output chunks. Default: True.
@@ -562,14 +574,9 @@ class CodeChunker(BaseChunker):
             TokenLimitError: Structural block exceeds max_tokens in strict mode.
             CallbackError: If the token counter fails or returns an invalid type.
         """
-        self._validate_constraints(max_tokens, max_lines, max_functions, token_counter)
-
-        if max_tokens is None:
-            max_tokens = sys.maxsize
-        if max_lines is None:
-            max_lines = sys.maxsize
-        if max_functions is None:
-            max_functions = sys.maxsize
+        max_tokens = self.max_tokens or sys.maxsize
+        max_lines = self.max_lines or sys.maxsize
+        max_functions = self.max_functions or sys.maxsize
 
         token_counter = token_counter or self.token_counter
 
@@ -607,9 +614,6 @@ class CodeChunker(BaseChunker):
         self,
         path: str | Path,
         *,
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_lines: Annotated[int | None, Field(ge=5)] = None,
-        max_functions: Annotated[int | None, Field(ge=1)] = None,
         token_counter: Callable[[str], int] | None = None,
         include_comments: bool = True,
         docstring_mode: Literal["summary", "all", "excluded"] = "all",
@@ -618,14 +622,11 @@ class CodeChunker(BaseChunker):
         """
         Extract semantic code chunks from source using multi-dimensional analysis.
         Processes source code by identifying structural boundaries (functions, classes,
-        namespaces) and grouping content based on multiple constraints including
-        tokens, lines, and logical units while preserving semantic coherence.
+        namespaces) and grouping content based on multiple constraints that are
+        configured at initialization while preserving semantic coherence.
 
         Args:
             path: File path to process.
-            max_tokens: Maximum tokens per chunk. Must be >= 12.
-            max_lines: Maximum number of lines per chunk. Must be >= 5.
-            max_functions: Maximum number of functions per chunk. Must be >= 1.
             token_counter: Token counting function. Uses instance
                 counter if None. Required for token-based chunking.
             include_comments: Include comments in output chunks. Default: True.
@@ -666,9 +667,6 @@ class CodeChunker(BaseChunker):
 
         return self.chunk_text(
             code=code,
-            max_tokens=max_tokens,
-            max_lines=max_lines,
-            max_functions=max_functions,
             token_counter=token_counter or self.token_counter,
             include_comments=include_comments,
             docstring_mode=docstring_mode,
@@ -680,9 +678,6 @@ class CodeChunker(BaseChunker):
         self,
         codes: IterableOfStr,
         *,
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_lines: Annotated[int | None, Field(ge=5)] = None,
-        max_functions: Annotated[int | None, Field(ge=1)] = None,
         token_counter: Callable[[str], int] | None = None,
         separator: Any = None,
         include_comments: bool = True,
@@ -699,9 +694,6 @@ class CodeChunker(BaseChunker):
 
         Args:
             codes: A non-string iterable of raw code strings.
-            max_tokens: Maximum tokens per chunk. Must be >= 12.
-            max_lines: Maximum number of lines per chunk. Must be >= 5.
-            max_functions: Maximum number of functions per chunk. Must be >= 1.
             token_counter: Token counting function. Uses instance
                 counter if None. Required for token-based chunking.
             separator: A value to be yielded after the chunks of each text are processed.
@@ -738,9 +730,6 @@ class CodeChunker(BaseChunker):
         """
         chunk_func = partial(
             self.chunk_text,
-            max_tokens=max_tokens,
-            max_lines=max_lines,
-            max_functions=max_functions,
             token_counter=token_counter or self.token_counter,
             include_comments=include_comments,
             docstring_mode=docstring_mode,
@@ -763,9 +752,6 @@ class CodeChunker(BaseChunker):
         self,
         paths: IterableOfPath,
         *,
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_lines: Annotated[int | None, Field(ge=5)] = None,
-        max_functions: Annotated[int | None, Field(ge=1)] = None,
         token_counter: Callable[[str], int] | None = None,
         separator: Any = None,
         include_comments: bool = True,
@@ -782,9 +768,6 @@ class CodeChunker(BaseChunker):
 
         Args:
             paths: A non-string iterable of file paths to process.
-            max_tokens: Maximum tokens per chunk. Must be >= 12.
-            max_lines: Maximum number of lines per chunk. Must be >= 5.
-            max_functions: Maximum number of functions per chunk. Must be >= 1.
             token_counter: Token counting function. Uses instance
                 counter if None. Required for token-based chunking.
             separator: A value to be yielded after the chunks of each text are processed.
@@ -822,9 +805,6 @@ class CodeChunker(BaseChunker):
         """
         chunk_func = partial(
             self.chunk_file,
-            max_tokens=max_tokens,
-            max_lines=max_lines,
-            max_functions=max_functions,
             token_counter=token_counter or self.token_counter,
             include_comments=include_comments,
             docstring_mode=docstring_mode,

--- a/src/chunklet/document_chunker/_plain_text_chunker.py
+++ b/src/chunklet/document_chunker/_plain_text_chunker.py
@@ -45,6 +45,15 @@ class PlainTextChunker:
         - Memory friendly batching: Yields chunks one at a time, reducing memory usage, especially for very large documents.
     """
 
+    # Attributes that feed into constraint validation; mutating any of them
+    # outside __init__ triggers _validate_constraints.
+    _VALIDATED_ATTRS = {
+        "max_tokens",
+        "max_sentences",
+        "max_section_breaks",
+        "token_counter",
+    }
+
     @validate_input
     def __init__(
         self,
@@ -86,6 +95,19 @@ class PlainTextChunker:
 
         self.sentence_splitter = SentenceSplitter()
         self.sentence_splitter.verbose = self._verbose
+        self._initialized = True
+
+    def __setattr__(self, name: str, value):
+        """Validate constraints whenever a constraint attribute is mutated."""
+        object.__setattr__(self, name, value)
+
+        if name in self._VALIDATED_ATTRS and self.__dict__.get("_initialized"):
+            self._validate_constraints(
+                self.max_tokens,
+                self.max_sentences,
+                self.max_section_breaks,
+                self.token_counter,
+            )
 
     @property
     def verbose(self) -> bool:

--- a/src/chunklet/document_chunker/_plain_text_chunker.py
+++ b/src/chunklet/document_chunker/_plain_text_chunker.py
@@ -48,22 +48,41 @@ class PlainTextChunker:
     @validate_input
     def __init__(
         self,
-        verbose: bool = False,
         continuation_marker: str = "...",
+        max_tokens: Annotated[int | None, Field(ge=12)] = None,
+        max_sentences: Annotated[int | None, Field(ge=1)] = None,
+        max_section_breaks: Annotated[int | None, Field(ge=1)] = None,
+        overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
+        offset: Annotated[int, Field(ge=0)] = 0,
         token_counter: Callable[[str], int] | None = None,
+        verbose: bool = False,
     ):
         """
         Initialize The PlainTextChunker.
 
         Args:
-            verbose: Enable verbose logging.
             continuation_marker: The marker to prepend to unfitted clauses. Defaults to '...'.
+            max_tokens: Maximum number of tokens per chunk. Must be >= 12.
+            max_sentences: Maximum number of sentences per chunk. Must be >= 1.
+            max_section_breaks: Maximum number of section breaks per chunk. Must be >= 1.
+            overlap_percent: Percentage of overlap between chunks (0-75). Defaults to 20.
+            offset: Starting sentence offset for chunking. Defaults to 0.
             token_counter: Function that counts tokens in text.
                 If None, must be provided when calling chunk() methods.
+            verbose: Enable verbose logging.
         """
         self._verbose = verbose
         self.token_counter = token_counter
         self.continuation_marker = continuation_marker
+        self.max_tokens = max_tokens
+        self.max_sentences = max_sentences
+        self.max_section_breaks = max_section_breaks
+        self.overlap_percent = overlap_percent
+        self.offset = offset
+
+        self._validate_constraints(
+            max_tokens, max_sentences, max_section_breaks, token_counter
+        )
 
         self.sentence_splitter = SentenceSplitter()
         self.sentence_splitter.verbose = self._verbose
@@ -438,27 +457,18 @@ class PlainTextChunker:
         text: str,
         *,
         lang: str = "auto",
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_sentences: Annotated[int | None, Field(ge=1)] = None,
-        max_section_breaks: Annotated[int | None, Field(ge=1)] = None,
-        overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
-        offset: Annotated[int, Field(ge=0)] = 0,
         token_counter: Callable[[str], int] | None = None,
         base_metadata: dict[str, Any] | None = None,
     ) -> list[DotDict]:
         """
-        Chunks a single text into smaller pieces based on specified parameters.
+        Chunks a single text into smaller pieces based on constraints
+        configured at initialization.
         Supports flexible constraint-based chunking, clause-level overlap,
         and custom token counters.
 
         Args:
             text: The input text to chunk.
             lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
-            max_tokens: Maximum number of tokens per chunk. Must be >= 12.
-            max_sentences: Maximum number of sentences per chunk. Must be >= 1.
-            max_section_breaks: Maximum number of section breaks per chunk. Must be >= 1.
-            overlap_percent: Percentage of overlap between chunks (0-75). Defaults to 20
-            offset: Starting sentence offset for chunking. Defaults to 0.
             token_counter: Optional token counting function.
                 Required for token-based modes only.
             base_metadata: Optional dictionary to be included with each chunk.
@@ -471,23 +481,15 @@ class PlainTextChunker:
             MissingTokenCounterError: If `max_tokens` is provided but no `token_counter` is provided.
             CallbackError: If an error occurs during sentence splitting or token counting within a chunking task.
         """
-        self._validate_constraints(
-            max_tokens, max_sentences, max_section_breaks, token_counter
-        )
+        max_tokens = self.max_tokens or sys.maxsize
+        max_sentences = self.max_sentences or sys.maxsize
+        max_section_breaks = self.max_section_breaks or sys.maxsize
 
         log_info(
             self.verbose,
             "Starting chunk processing for text starting with: {}.",
             f"{text[:100]}...",
         )
-
-        # Adjust limits for _group_by_chunk's internal use
-        if max_tokens is None:
-            max_tokens = sys.maxsize
-        if max_sentences is None:
-            max_sentences = sys.maxsize
-        if max_section_breaks is None:
-            max_section_breaks = sys.maxsize
 
         if not text.strip():
             log_info(self.verbose, "Input text is empty. Returning empty list.")
@@ -507,7 +509,7 @@ class PlainTextChunker:
         if not sentences:
             return []
 
-        offset = round(offset)
+        offset = round(self.offset)
         if offset >= len(sentences):
             logger.warning(
                 "Offset {} >= total sentences {}. Returning empty list.",
@@ -522,7 +524,7 @@ class PlainTextChunker:
             max_tokens=max_tokens,
             max_sentences=max_sentences,
             max_section_breaks=max_section_breaks,
-            overlap_percent=overlap_percent,
+            overlap_percent=self.overlap_percent,
         )
 
         # Note: We use DeterministicSpanFinder because sentence splitter may modify text
@@ -536,11 +538,6 @@ class PlainTextChunker:
         texts: IterableOfStr,
         *,
         lang: str = "auto",
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_sentences: Annotated[int | None, Field(ge=1)] = None,
-        max_section_breaks: Annotated[int | None, Field(ge=1)] = None,
-        overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
-        offset: Annotated[int, Field(ge=0)] = 0,
         token_counter: Callable[[str], int] | None = None,
         separator: Any = None,
         base_metadata: dict[str, Any] | None = None,
@@ -551,6 +548,7 @@ class PlainTextChunker:
         """
         Processes a batch of texts in parallel, splitting each into chunks.
         Leverages multiprocessing for efficient batch chunking.
+        Uses the constraints configured at initialization.
 
         If a task fails, `chunklet` will now stop processing and return the results
         of the tasks that completed successfully, preventing wasted work.
@@ -558,11 +556,6 @@ class PlainTextChunker:
         Args:
             texts: A non-string iterable of input texts to be chunked.
             lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
-            max_tokens: Maximum number of tokens per chunk. Must be >= 12.
-            max_sentences: Maximum number of sentences per chunk. Must be >= 1.
-            max_section_breaks: Maximum number of section breaks per chunk. Must be >= 1.
-            overlap_percent: Percentage of overlap between chunks (0-85).
-            offset: Starting sentence offset for chunking. Defaults to 0.
             token_counter: The token counting function.
                 Required if `max_tokens` is set.
             separator: A value to be yielded after the chunks of each text are processed.
@@ -586,11 +579,6 @@ class PlainTextChunker:
         chunk_func = partial(
             self.chunk,
             lang=lang,
-            max_tokens=max_tokens,
-            max_sentences=max_sentences,
-            overlap_percent=overlap_percent,
-            max_section_breaks=max_section_breaks,
-            offset=offset,
             base_metadata=base_metadata,
             token_counter=token_counter or self.token_counter,
         )

--- a/src/chunklet/document_chunker/_plain_text_chunker.py
+++ b/src/chunklet/document_chunker/_plain_text_chunker.py
@@ -70,17 +70,9 @@ class PlainTextChunker:
         """
         Initialize The PlainTextChunker.
 
-        Args:
-            continuation_marker: The marker to prepend to unfitted clauses. Defaults to '...'.
-            max_tokens: Maximum number of tokens per chunk. Must be >= 12.
-            max_sentences: Maximum number of sentences per chunk. Must be >= 1.
-            max_section_breaks: Maximum number of section breaks per chunk. Must be >= 1.
-            overlap_percent: Percentage of overlap between chunks (0-75). Defaults to 20.
-            offset: Starting sentence offset for chunking. Defaults to 0.
-            token_counter: Function that counts tokens in text.
-                If None, must be provided when calling chunk() methods.
-            lang: Language code (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
-            verbose: Enable verbose logging.
+        Constraints limit how each chunk is shaped; `lang` selects the language
+        used for splitting. Limit constraints are validated at construction and
+        on mutation. Args are documented on `DocumentChunker`.
         """
         self._verbose = verbose
         self.token_counter = token_counter
@@ -96,8 +88,7 @@ class PlainTextChunker:
             max_tokens, max_sentences, max_section_breaks, token_counter
         )
 
-        self.sentence_splitter = SentenceSplitter(lang=lang)
-        self.sentence_splitter.verbose = self._verbose
+        self.sentence_splitter = SentenceSplitter(lang=lang, verbose=self._verbose)
         self._initialized = True
 
     def __setattr__(self, name: str, value):

--- a/src/chunklet/document_chunker/_plain_text_chunker.py
+++ b/src/chunklet/document_chunker/_plain_text_chunker.py
@@ -3,16 +3,14 @@ import re
 import sys
 from collections.abc import Iterable
 from functools import partial
-from typing import Annotated, Any, Callable, Generator, Literal
+from typing import Any, Callable, Generator, Literal
 
 from loguru import logger
-from pydantic import Field
 
 from chunklet.common.batch_runner import run_in_batch
 from chunklet.common.dotdict import DotDict
 from chunklet.common.logging_utils import log_info
 from chunklet.common.token_utils import count_tokens
-from chunklet.common.validation import IterableOfStr, validate_input
 from chunklet.document_chunker.span_finder import DeterministicSpanFinder
 from chunklet.exceptions import (
     CallbackError,
@@ -54,15 +52,14 @@ class PlainTextChunker:
         "token_counter",
     }
 
-    @validate_input
     def __init__(
         self,
         continuation_marker: str = "...",
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_sentences: Annotated[int | None, Field(ge=1)] = None,
-        max_section_breaks: Annotated[int | None, Field(ge=1)] = None,
-        overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
-        offset: Annotated[int, Field(ge=0)] = 0,
+        max_tokens: int | None = None,
+        max_sentences: int | None = None,
+        max_section_breaks: int | None = None,
+        overlap_percent: int = 20,
+        offset: int = 0,
         token_counter: Callable[[str], int] | None = None,
         lang: str = "auto",
         verbose: bool = False,
@@ -467,7 +464,6 @@ class PlainTextChunker:
         if max_tokens is not None and not (token_counter or self.token_counter):
             raise MissingTokenCounterError()
 
-    @validate_input
     def chunk(
         self,
         text: str,
@@ -544,15 +540,14 @@ class PlainTextChunker:
         span_finder = DeterministicSpanFinder(text)
         return self._create_chunks(chunks, base_metadata or {}, span_finder)
 
-    @validate_input
     def batch_chunk(
         self,
-        texts: IterableOfStr,
+        texts: Iterable[str],
         *,
         token_counter: Callable[[str], int] | None = None,
         separator: Any = None,
         base_metadata: dict[str, Any] | None = None,
-        n_jobs: Annotated[int, Field(ge=1)] | None = None,
+        n_jobs: int | None = None,
         show_progress: bool = True,
         on_errors: Literal["raise", "skip", "break"] = "raise",
     ) -> Generator[Any, None, None]:

--- a/src/chunklet/document_chunker/_plain_text_chunker.py
+++ b/src/chunklet/document_chunker/_plain_text_chunker.py
@@ -64,6 +64,7 @@ class PlainTextChunker:
         overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
         offset: Annotated[int, Field(ge=0)] = 0,
         token_counter: Callable[[str], int] | None = None,
+        lang: str = "auto",
         verbose: bool = False,
     ):
         """
@@ -78,6 +79,7 @@ class PlainTextChunker:
             offset: Starting sentence offset for chunking. Defaults to 0.
             token_counter: Function that counts tokens in text.
                 If None, must be provided when calling chunk() methods.
+            lang: Language code (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
             verbose: Enable verbose logging.
         """
         self._verbose = verbose
@@ -88,12 +90,13 @@ class PlainTextChunker:
         self.max_section_breaks = max_section_breaks
         self.overlap_percent = overlap_percent
         self.offset = offset
+        self.lang = lang
 
         self._validate_constraints(
             max_tokens, max_sentences, max_section_breaks, token_counter
         )
 
-        self.sentence_splitter = SentenceSplitter()
+        self.sentence_splitter = SentenceSplitter(lang=lang)
         self.sentence_splitter.verbose = self._verbose
         self._initialized = True
 
@@ -478,7 +481,6 @@ class PlainTextChunker:
         self,
         text: str,
         *,
-        lang: str = "auto",
         token_counter: Callable[[str], int] | None = None,
         base_metadata: dict[str, Any] | None = None,
     ) -> list[DotDict]:
@@ -490,7 +492,6 @@ class PlainTextChunker:
 
         Args:
             text: The input text to chunk.
-            lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
             token_counter: Optional token counting function.
                 Required for token-based modes only.
             base_metadata: Optional dictionary to be included with each chunk.
@@ -517,11 +518,9 @@ class PlainTextChunker:
             log_info(self.verbose, "Input text is empty. Returning empty list.")
             return []
 
+        self.sentence_splitter.lang = self.lang
         try:
-            sentences = self.sentence_splitter.split_text(
-                text,
-                lang,
-            )
+            sentences = self.sentence_splitter.split_text(text)
         except Exception as e:
             raise CallbackError(
                 f"An error occurred during the sentence splitting process.\nDetails: {e}\n"
@@ -559,7 +558,6 @@ class PlainTextChunker:
         self,
         texts: IterableOfStr,
         *,
-        lang: str = "auto",
         token_counter: Callable[[str], int] | None = None,
         separator: Any = None,
         base_metadata: dict[str, Any] | None = None,
@@ -577,7 +575,6 @@ class PlainTextChunker:
 
         Args:
             texts: A non-string iterable of input texts to be chunked.
-            lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
             token_counter: The token counting function.
                 Required if `max_tokens` is set.
             separator: A value to be yielded after the chunks of each text are processed.
@@ -600,7 +597,6 @@ class PlainTextChunker:
         """
         chunk_func = partial(
             self.chunk,
-            lang=lang,
             base_metadata=base_metadata,
             token_counter=token_counter or self.token_counter,
         )

--- a/src/chunklet/document_chunker/document_chunker.py
+++ b/src/chunklet/document_chunker/document_chunker.py
@@ -88,6 +88,7 @@ class DocumentChunker(BaseChunker):
         "lang",
     }
 
+    @validate_input
     def __init__(
         self,
         processor_registry: CustomProcessorRegistry | None = None,

--- a/src/chunklet/document_chunker/document_chunker.py
+++ b/src/chunklet/document_chunker/document_chunker.py
@@ -77,6 +77,18 @@ class DocumentChunker(BaseChunker):
         ".xlsx",
     }
 
+    # Constraints stored on the internal PlainTextChunker; attribute access on
+    # this class is delegated so they can be read/mutated from the outside.
+    _DELEGATED_CONSTRAINTS = frozenset(
+        {
+            "max_tokens",
+            "max_sentences",
+            "max_section_breaks",
+            "overlap_percent",
+            "offset",
+        }
+    )
+
     def __init__(
         self,
         processor_registry: CustomProcessorRegistry | None = None,
@@ -158,6 +170,26 @@ class DocumentChunker(BaseChunker):
         """Set the verbosity and propagate to plain_text_chunker."""
         self._verbose = value
         self.plain_text_chunker.verbose = value
+
+    def __getattr__(self, name: str):
+        """Proxy any constraint attribute access to the internal PlainTextChunker."""
+        if name in self._DELEGATED_CONSTRAINTS:
+            plain_text_chunker = self.__dict__.get("plain_text_chunker")
+            if plain_text_chunker is not None:
+                return getattr(plain_text_chunker, name)
+        raise AttributeError(
+            f"{type(self).__name__!r} object has no attribute {name!r}"
+        )
+
+    def __setattr__(self, name: str, value):
+        """Propagate constraint attribute assignment to the internal PlainTextChunker."""
+        if (
+            name in self._DELEGATED_CONSTRAINTS
+            and "plain_text_chunker" in self.__dict__
+        ):
+            setattr(self.plain_text_chunker, name, value)
+        else:
+            object.__setattr__(self, name, value)
 
     def _validate_and_get_extension(self, path: Path) -> str:
         """

--- a/src/chunklet/document_chunker/document_chunker.py
+++ b/src/chunklet/document_chunker/document_chunker.py
@@ -79,21 +79,33 @@ class DocumentChunker(BaseChunker):
 
     def __init__(
         self,
-        verbose: bool = False,
-        continuation_marker: str = "...",
-        token_counter: Callable[[str], int] | None = None,
         processor_registry: CustomProcessorRegistry | None = None,
+        continuation_marker: str = "...",
+        max_tokens: Annotated[int | None, Field(ge=12)] = None,
+        max_sentences: Annotated[int | None, Field(ge=1)] = None,
+        max_section_breaks: Annotated[int | None, Field(ge=1)] = None,
+        overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
+        offset: Annotated[int, Field(ge=0)] = 0,
+        token_counter: Callable[[str], int] | None = None,
+        verbose: bool = False,
     ):
         """
         Initializes the DocumentChunker.
 
         Args:
-            verbose: Enable verbose logging.
-            continuation_marker: The marker to prepend to unfitted clauses. Defaults to '...'.
-            token_counter: Function that counts tokens in text.
-                If None, must be provided when calling chunk() methods.
             processor_registry: An optional CustomProcessorRegistry instance to use for
                 custom document processors. If None, a fresh registry is created.
+            continuation_marker: The marker to prepend to unfitted clauses. Defaults to '...'.
+            max_tokens: Maximum number of tokens per chunk. Must be >= 12.
+            max_sentences: Maximum number of sentences per chunk. Must be >= 1.
+            max_section_breaks: Maximum number of section breaks per chunk.
+                Section breaks include Markdown headings (# to ######), horizontal rules (---, ***, ___), and <details> tags.
+                Must be >= 1.
+            overlap_percent: Percentage of overlap between chunks (0-75). Defaults to 20.
+            offset: Starting sentence offset for chunking. Defaults to 0.
+            token_counter: Function that counts tokens in text.
+                If None, must be provided (or token-based limits disabled).
+            verbose: Enable verbose logging.
         """
         self._verbose = verbose
         self.token_counter = token_counter
@@ -101,9 +113,14 @@ class DocumentChunker(BaseChunker):
         self.processor_registry = processor_registry or CustomProcessorRegistry()
 
         self.plain_text_chunker = PlainTextChunker(
-            verbose=self._verbose,
             continuation_marker=self.continuation_marker,
+            max_tokens=max_tokens,
+            max_sentences=max_sentences,
+            max_section_breaks=max_section_breaks,
+            overlap_percent=overlap_percent,
+            offset=offset,
             token_counter=self.token_counter,
+            verbose=self._verbose,
         )
 
         self.processors = {
@@ -332,29 +349,16 @@ class DocumentChunker(BaseChunker):
         text: str,
         *,
         lang: str = "auto",
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_sentences: Annotated[int | None, Field(ge=1)] = None,
-        max_section_breaks: Annotated[int | None, Field(ge=1)] = None,
-        overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
-        offset: Annotated[int, Field(ge=0)] = 0,
         token_counter: Callable[[str], int] | None = None,
         base_metadata: dict[str, Any] | None = None,
     ) -> list[DotDict]:
         """
-        Chunks raw text content.
+        Chunks raw text content using the constraints configured at initialization.
 
         Args:
             text: The raw text to chunk.
             lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
-            max_tokens: Maximum number of tokens per chunk. Must be >= 12.
-            max_sentences: Maximum number of sentences per chunk. Must be >= 1.
-            max_section_breaks: Maximum number of section breaks per chunk.
-                Section breaks include Markdown headings (# to ######), horizontal rules (---, ***, ___), and <details> tags.
-                Must be >= 1.
-            overlap_percent: Percentage of overlap between chunks (0-85).
-            offset: Starting sentence offset for chunking. Defaults to 0.
             token_counter: Optional token counting function.
-                Required if `max_tokens` is provided.
             base_metadata: Optional dictionary to be included with each chunk.
 
         Returns:
@@ -370,11 +374,6 @@ class DocumentChunker(BaseChunker):
         texts: IterableOfStr,
         *,
         lang: str = "auto",
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_sentences: Annotated[int | None, Field(ge=1)] = None,
-        max_section_breaks: Annotated[int | None, Field(ge=1)] = None,
-        overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
-        offset: Annotated[int, Field(ge=0)] = 0,
         token_counter: Callable[[str], int] | None = None,
         base_metadata: dict[str, Any] | None = None,
         separator: Any = None,
@@ -383,20 +382,13 @@ class DocumentChunker(BaseChunker):
         on_errors: Literal["raise", "skip", "break"] = "raise",
     ) -> Generator[DotDict, None, None]:
         """
-        Chunks multiple text contents.
+        Chunks multiple text contents using the constraints configured
+        at initialization.
 
         Args:
             texts: A non-string iterable of texts to chunk.
             lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
-            max_tokens: Maximum number of tokens per chunk. Must be >= 12.
-            max_sentences: Maximum number of sentences per chunk. Must be >= 1.
-            max_section_breaks: Maximum number of section breaks per chunk.
-                Section breaks include Markdown headings (# to ######), horizontal rules (---, ***, ___), and <details> tags.
-                Must be >= 1.
-            overlap_percent: Percentage of overlap between chunks (0-85).
-            offset: Starting sentence offset for chunking. Defaults to 0.
             token_counter: Optional token counting function.
-                Required if `max_tokens` is provided.
             base_metadata: Optional dictionary to be included with each chunk.
             separator: A value to be yielded after the chunks of each text are processed.
             n_jobs: Number of parallel workers.
@@ -422,15 +414,11 @@ class DocumentChunker(BaseChunker):
         path: str | Path,
         *,
         lang: str = "auto",
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_sentences: Annotated[int | None, Field(ge=1)] = None,
-        max_section_breaks: Annotated[int | None, Field(ge=1)] = None,
-        overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
-        offset: Annotated[int, Field(ge=0)] = 0,
         token_counter: Callable[[str], int] | None = None,
     ) -> list[DotDict]:
         """
-        Chunks a single document from a given path.
+        Chunks a single document from a given path using the constraints
+        configured at initialization.
 
         This method automatically detects the file type and uses the appropriate
         processor to extract text before chunking. It then adds document-level
@@ -439,15 +427,7 @@ class DocumentChunker(BaseChunker):
         Args:
             path: The path to the document file.
             lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
-            max_tokens: Maximum number of tokens per chunk. Must be >= 12.
-            max_sentences: Maximum number of sentences per chunk. Must be >= 1.
-            max_section_breaks: Maximum number of section breaks per chunk.
-                Section breaks include Markdown headings (# to ######), horizontal rules (---, ***, ___), and <details> tags.
-                Must be >= 1.
-            overlap_percent: Percentage of overlap between chunks (0-85).
-            offset: Starting sentence offset for chunking. Defaults to 0.
             token_counter: Optional token counting function.
-                Required if `max_tokens` is provided.
 
         Returns:
             A list of `DotDict` objects, each representing
@@ -478,11 +458,6 @@ class DocumentChunker(BaseChunker):
         chunks_out = self.plain_text_chunker.chunk(
             text=text_content,
             lang=lang,
-            max_tokens=max_tokens,
-            max_sentences=max_sentences,
-            max_section_breaks=max_section_breaks,
-            overlap_percent=overlap_percent,
-            offset=offset,
             token_counter=token_counter or self.token_counter,
         )
 
@@ -499,11 +474,6 @@ class DocumentChunker(BaseChunker):
         paths: IterableOfPath,
         *,
         lang: str = "auto",
-        max_tokens: Annotated[int | None, Field(ge=12)] = None,
-        max_sentences: Annotated[int | None, Field(ge=1)] = None,
-        max_section_breaks: Annotated[int | None, Field(ge=1)] = None,
-        overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
-        offset: Annotated[int, Field(ge=0)] = 0,
         token_counter: Callable[[str], int] | None = None,
         separator: Any = None,
         n_jobs: Annotated[int, Field(ge=1)] | None = None,
@@ -511,7 +481,8 @@ class DocumentChunker(BaseChunker):
         on_errors: Literal["raise", "skip", "break"] = "raise",
     ) -> Generator[DotDict, None, None]:
         """
-        Chunks multiple documents from a list of file paths.
+        Chunks multiple documents from a list of file paths using the constraints
+        configured at initialization.
 
         This method is a memory-efficient generator that yields chunks as they
         are processed, without loading all documents into memory at once. It
@@ -520,15 +491,7 @@ class DocumentChunker(BaseChunker):
         Args:
             paths: A non-string iterable of paths to the document files.
             lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
-            max_tokens: Maximum number of tokens per chunk. Must be >= 12.
-            max_sentences: Maximum number of sentences per chunk. Must be >= 1.
-            max_section_breaks: Maximum number of section breaks per chunk.
-                Section breaks include Markdown headings (# to ######), horizontal rules (---, ***, ___), and <details> tags.
-                Must be >= 1.
-            overlap_percent: Percentage of overlap between chunks (0-85).
-            offset: Starting sentence offset for chunking. Defaults to 0.
             token_counter: Optional token counting function.
-                Required if `max_tokens` is provided.
             separator: A value to be yielded after the chunks of each text are processed.
                 Note: None cannot be used as a separator.
 
@@ -554,11 +517,6 @@ class DocumentChunker(BaseChunker):
         all_chunks_gen = self.plain_text_chunker.batch_chunk(
             texts=list(batch_documents["all_texts_gen"]),
             lang=lang,
-            max_tokens=max_tokens,
-            max_sentences=max_sentences,
-            max_section_breaks=max_section_breaks,
-            overlap_percent=overlap_percent,
-            offset=offset,
             token_counter=token_counter or self.token_counter,
             separator=sentinel,
             n_jobs=n_jobs,

--- a/src/chunklet/document_chunker/document_chunker.py
+++ b/src/chunklet/document_chunker/document_chunker.py
@@ -79,15 +79,13 @@ class DocumentChunker(BaseChunker):
 
     # Constraints stored on the internal PlainTextChunker; attribute access on
     # this class is delegated so they can be read/mutated from the outside.
-    _DELEGATED_CONSTRAINTS = frozenset(
-        {
-            "max_tokens",
-            "max_sentences",
-            "max_section_breaks",
-            "overlap_percent",
-            "offset",
-        }
-    )
+    _DELEGATED_CONSTRAINTS = {
+        "max_tokens",
+        "max_sentences",
+        "max_section_breaks",
+        "overlap_percent",
+        "offset",
+    }
 
     def __init__(
         self,
@@ -152,25 +150,6 @@ class DocumentChunker(BaseChunker):
             ".xlsx": table_2_md.table_to_md,
         }
 
-    @property
-    def supported_extensions(self):
-        """Get the supported extensions, including the custom ones."""
-        return (
-            self.BUILTIN_SUPPORTED_EXTENSIONS
-            | self.processor_registry.processors.keys()
-        )
-
-    @property
-    def verbose(self) -> bool:
-        """Get the verbosity status."""
-        return self._verbose
-
-    @verbose.setter
-    def verbose(self, value: bool):
-        """Set the verbosity and propagate to plain_text_chunker."""
-        self._verbose = value
-        self.plain_text_chunker.verbose = value
-
     def __getattr__(self, name: str):
         """Proxy any constraint attribute access to the internal PlainTextChunker."""
         if name in self._DELEGATED_CONSTRAINTS:
@@ -190,6 +169,25 @@ class DocumentChunker(BaseChunker):
             setattr(self.plain_text_chunker, name, value)
         else:
             object.__setattr__(self, name, value)
+
+    @property
+    def supported_extensions(self):
+        """Get the supported extensions, including the custom ones."""
+        return (
+            self.BUILTIN_SUPPORTED_EXTENSIONS
+            | self.processor_registry.processors.keys()
+        )
+
+    @property
+    def verbose(self) -> bool:
+        """Get the verbosity status."""
+        return self._verbose
+
+    @verbose.setter
+    def verbose(self, value: bool):
+        """Set the verbosity and propagate to plain_text_chunker."""
+        self._verbose = value
+        self.plain_text_chunker.verbose = value
 
     def _validate_and_get_extension(self, path: Path) -> str:
         """

--- a/src/chunklet/document_chunker/document_chunker.py
+++ b/src/chunklet/document_chunker/document_chunker.py
@@ -85,6 +85,7 @@ class DocumentChunker(BaseChunker):
         "max_section_breaks",
         "overlap_percent",
         "offset",
+        "lang",
     }
 
     def __init__(
@@ -97,6 +98,7 @@ class DocumentChunker(BaseChunker):
         overlap_percent: Annotated[int, Field(ge=0, le=75)] = 20,
         offset: Annotated[int, Field(ge=0)] = 0,
         token_counter: Callable[[str], int] | None = None,
+        lang: str = "auto",
         verbose: bool = False,
     ):
         """
@@ -115,6 +117,7 @@ class DocumentChunker(BaseChunker):
             offset: Starting sentence offset for chunking. Defaults to 0.
             token_counter: Function that counts tokens in text.
                 If None, must be provided (or token-based limits disabled).
+            lang: Language code (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
             verbose: Enable verbose logging.
         """
         self._verbose = verbose
@@ -130,6 +133,7 @@ class DocumentChunker(BaseChunker):
             overlap_percent=overlap_percent,
             offset=offset,
             token_counter=self.token_counter,
+            lang=lang,
             verbose=self._verbose,
         )
 
@@ -378,7 +382,6 @@ class DocumentChunker(BaseChunker):
         self,
         text: str,
         *,
-        lang: str = "auto",
         token_counter: Callable[[str], int] | None = None,
         base_metadata: dict[str, Any] | None = None,
     ) -> list[DotDict]:
@@ -387,7 +390,6 @@ class DocumentChunker(BaseChunker):
 
         Args:
             text: The raw text to chunk.
-            lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
             token_counter: Optional token counting function.
             base_metadata: Optional dictionary to be included with each chunk.
 
@@ -403,7 +405,6 @@ class DocumentChunker(BaseChunker):
         self,
         texts: IterableOfStr,
         *,
-        lang: str = "auto",
         token_counter: Callable[[str], int] | None = None,
         base_metadata: dict[str, Any] | None = None,
         separator: Any = None,
@@ -417,7 +418,6 @@ class DocumentChunker(BaseChunker):
 
         Args:
             texts: A non-string iterable of texts to chunk.
-            lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
             token_counter: Optional token counting function.
             base_metadata: Optional dictionary to be included with each chunk.
             separator: A value to be yielded after the chunks of each text are processed.
@@ -443,7 +443,6 @@ class DocumentChunker(BaseChunker):
         self,
         path: str | Path,
         *,
-        lang: str = "auto",
         token_counter: Callable[[str], int] | None = None,
     ) -> list[DotDict]:
         """
@@ -456,7 +455,6 @@ class DocumentChunker(BaseChunker):
 
         Args:
             path: The path to the document file.
-            lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
             token_counter: Optional token counting function.
 
         Returns:
@@ -487,7 +485,6 @@ class DocumentChunker(BaseChunker):
 
         chunks_out = self.plain_text_chunker.chunk(
             text=text_content,
-            lang=lang,
             token_counter=token_counter or self.token_counter,
         )
 
@@ -503,7 +500,6 @@ class DocumentChunker(BaseChunker):
         self,
         paths: IterableOfPath,
         *,
-        lang: str = "auto",
         token_counter: Callable[[str], int] | None = None,
         separator: Any = None,
         n_jobs: Annotated[int, Field(ge=1)] | None = None,
@@ -520,7 +516,6 @@ class DocumentChunker(BaseChunker):
 
         Args:
             paths: A non-string iterable of paths to the document files.
-            lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
             token_counter: Optional token counting function.
             separator: A value to be yielded after the chunks of each text are processed.
                 Note: None cannot be used as a separator.
@@ -546,7 +541,6 @@ class DocumentChunker(BaseChunker):
 
         all_chunks_gen = self.plain_text_chunker.batch_chunk(
             texts=list(batch_documents["all_texts_gen"]),
-            lang=lang,
             token_counter=token_counter or self.token_counter,
             separator=sentinel,
             n_jobs=n_jobs,

--- a/src/chunklet/document_chunker/registry.py
+++ b/src/chunklet/document_chunker/registry.py
@@ -190,4 +190,3 @@ class CustomProcessorRegistry:
             ) from None
 
         return result, name
-

--- a/src/chunklet/sentence_splitter/sentence_splitter.py
+++ b/src/chunklet/sentence_splitter/sentence_splitter.py
@@ -35,11 +35,16 @@ class SentenceSplitter:
     """
 
     @validate_input
-    def __init__(self, verbose: bool = False):
+    def __init__(
+        self,
+        lang: str = "auto",
+        verbose: bool = False,
+    ):
         """
         Initializes the SentenceSplitter.
 
         Args:
+            lang: Language code (e.g., 'en', 'fr', 'auto'). Defaults to "auto".
             verbose: If True, enables verbose logging for debugging and informational messages.
         """
         self.verbose = verbose
@@ -52,6 +57,8 @@ class SentenceSplitter:
 
         # Tracked to reduce log spamming about language detection
         self._last_lang_used = None
+
+        self.lang = lang
 
     @staticmethod
     @lru_cache(maxsize=52)
@@ -134,26 +141,29 @@ class SentenceSplitter:
         return lang_detected, confidence
 
     @validate_input
-    def split_text(self, text: str, lang: str = "auto") -> list[str]:
+    def split_text(self, text: str) -> list[str]:
         """
         Splits a given text into a list of sentences.
 
         Args:
             text: The input text to be split.
-            lang: The language of the text (e.g., 'en', 'fr'). Defaults to 'auto'
 
         Returns:
             A list of sentences.
 
         Examples:
-            >>> splitter = SentenceSplitter()
-            >>> splitter.split_text("Hello world. How are you?", "en")
+            >>> splitter = SentenceSplitter(lang="en")
+            >>> splitter.split_text("Hello world. How are you?")
             ['Hello world.', 'How are you?']
-            >>> splitter.split_text("Bonjour le monde. Comment allez-vous?", "fr")
+            >>> splitter = SentenceSplitter(lang="fr")
+            >>> splitter.split_text("Bonjour le monde. Comment allez-vous?")
             ['Bonjour le monde.', 'Comment allez-vous?']
-            >>> splitter.split_text("Hello world. How are you?", "auto")
+            >>> splitter = SentenceSplitter()
+            >>> splitter.split_text("Hello world. How are you?")
             ['Hello world.', 'How are you?']
         """
+        lang = self.lang
+
         if not text:
             log_info(self.verbose, "Input text is empty. Returning empty list.")
             return []
@@ -192,16 +202,15 @@ class SentenceSplitter:
         )
         return cleaned_sentences
 
-    def split_file(self, path: str | Path, lang: str = "auto") -> list[str]:
+    def split_file(self, path: str | Path) -> list[str]:
         """
         Read and split a file into sentences.
 
         Args:
             path: Path to the file to read.
-            lang: The language of the text (e.g., 'en', 'fr', 'auto'). Defaults to 'auto'.
 
         Returns:
             A list of sentences extracted from the file.
         """
         content = read_text_file(path)
-        return self.split_text(content, lang)
+        return self.split_text(content)

--- a/src/chunklet/sentence_splitter/sentence_splitter.py
+++ b/src/chunklet/sentence_splitter/sentence_splitter.py
@@ -170,9 +170,10 @@ class SentenceSplitter:
         self._last_lang_used = lang
 
         sentences = None
-        if lang != "fallback" and (
-            handler := self._get_lang_handler(lang, self.verbose)
-        ) is not None:
+        if (
+            lang != "fallback"
+            and (handler := self._get_lang_handler(lang, self.verbose)) is not None
+        ):
             sentences = handler(text)
 
         # If no handler found, use fallback

--- a/src/chunklet/visualizer/visualizer.py
+++ b/src/chunklet/visualizer/visualizer.py
@@ -85,9 +85,12 @@ class Visualizer:
 
         self.app = FastAPI()
 
-        # Initialize chunkers
-        self.document_chunker = DocumentChunker(token_counter=token_counter)
-        self.code_chunker = CodeChunker(token_counter=token_counter)
+        # Initialize chunkers with sensible defaults; constraint attributes are
+        # mutated per request from the submitted params.
+        self.document_chunker = DocumentChunker(
+            token_counter=token_counter, max_sentences=3
+        )
+        self.code_chunker = CodeChunker(token_counter=token_counter, max_lines=50)
 
         self.static_dir = Path(__file__).parent / "static"
 
@@ -172,12 +175,24 @@ class Visualizer:
         content = await file.read()
         encoding = detect(content).get("encoding", "utf-8")
         text = content.decode(encoding, errors="ignore")
-        chunker = self.code_chunker if mode == "code" else self.document_chunker
 
         try:
-            chunks = [
-                dict(chunk) for chunk in chunker.chunk_text(text, **chunker_params)
-            ]
+            if mode == "code":
+                # 'strict' is a per-call arg; the rest are constraint attributes.
+                strict = chunker_params.pop("strict", True)
+                chunker = self.code_chunker
+                for key, value in chunker_params.items():
+                    setattr(chunker, key, value)
+                chunks = [
+                    dict(chunk) for chunk in chunker.chunk_text(text, strict=strict)
+                ]
+            else:
+                # 'lang' is a per-call arg; the rest are constraint attributes.
+                lang = chunker_params.pop("lang", "auto")
+                chunker = self.document_chunker
+                for key, value in chunker_params.items():
+                    setattr(chunker, key, value)
+                chunks = [dict(chunk) for chunk in chunker.chunk_text(text, lang=lang)]
 
             response_data = {
                 "text": text,

--- a/src/chunklet/visualizer/visualizer.py
+++ b/src/chunklet/visualizer/visualizer.py
@@ -187,12 +187,10 @@ class Visualizer:
                     dict(chunk) for chunk in chunker.chunk_text(text, strict=strict)
                 ]
             else:
-                # 'lang' is a per-call arg; the rest are constraint attributes.
-                lang = chunker_params.pop("lang", "auto")
                 chunker = self.document_chunker
                 for key, value in chunker_params.items():
                     setattr(chunker, key, value)
-                chunks = [dict(chunk) for chunk in chunker.chunk_text(text, lang=lang)]
+                chunks = [dict(chunk) for chunk in chunker.chunk_text(text)]
 
             response_data = {
                 "text": text,

--- a/tests/test_code_chunking.py
+++ b/tests/test_code_chunking.py
@@ -139,7 +139,7 @@ MULTIPLE_SOURCES = [PYTHON_CODE, CSHARP_CODE, RUBY_CODE]
 @pytest.fixture
 def chunker():
     """Provide a ready-to-use CodeChunker instance for tests."""
-    return CodeChunker(token_counter=simple_token_counter)
+    return CodeChunker(token_counter=simple_token_counter, max_tokens=200)
 
 
 # --- Language Paradigm Tests ---
@@ -159,12 +159,13 @@ def test_chunking_with_different_constraints(
     chunker, code_string, max_tokens, max_lines, max_functions, expected_num_chunks
 ):
     """Test chunking with different constraints (max_tokens, max_lines, max_functions)."""
-    chunks = chunker.chunk_text(
-        code_string,
+    chunker = CodeChunker(
+        token_counter=simple_token_counter,
         max_tokens=max_tokens,
         max_lines=max_lines,
         max_functions=max_functions,
     )
+    chunks = chunker.chunk_text(code_string)
 
     assert len(chunks) > 0
     if max_tokens is not None:
@@ -224,7 +225,7 @@ def test_chunking_with_different_constraints(
 def test_docstring_modes(chunker, code_string, all_mode_pattern, summary_mode_pattern):
     """Test docstring processing modes for Python and C#."""
     # Test "all" mode - full docstring should be present
-    chunks_all = chunker.chunk_text(code_string, max_tokens=200, docstring_mode="all")
+    chunks_all = chunker.chunk_text(code_string, docstring_mode="all")
     content_all = "".join(chunk.content for chunk in chunks_all)
 
     assert re.search(all_mode_pattern, content_all, re.DOTALL), (
@@ -232,9 +233,7 @@ def test_docstring_modes(chunker, code_string, all_mode_pattern, summary_mode_pa
     )
 
     # Test "excluded" mode - docstring should be absent
-    chunks_excluded = chunker.chunk_text(
-        code_string, max_tokens=200, docstring_mode="excluded"
-    )
+    chunks_excluded = chunker.chunk_text(code_string, docstring_mode="excluded")
     content_excluded = "".join(chunk.content for chunk in chunks_excluded)
 
     assert not re.search(all_mode_pattern, content_excluded, re.DOTALL), (
@@ -242,9 +241,7 @@ def test_docstring_modes(chunker, code_string, all_mode_pattern, summary_mode_pa
     )
 
     # Test "summary" mode - only summary should be present
-    chunks_summary = chunker.chunk_text(
-        code_string, max_tokens=200, docstring_mode="summary"
-    )
+    chunks_summary = chunker.chunk_text(code_string, docstring_mode="summary")
     content_summary = "".join(chunk.content for chunk in chunks_summary)
 
     assert re.search(summary_mode_pattern, content_summary), (
@@ -272,9 +269,7 @@ def test_docstring_modes(chunker, code_string, all_mode_pattern, summary_mode_pa
 @pytest.mark.parametrize("include_comments", [True, False])
 def test_comment_inclusion(chunker, include_comments):
     """Test Inclusion/Exclusion Of Comments."""
-    chunks = chunker.chunk_text(
-        PYTHON_CODE, max_tokens=200, include_comments=include_comments
-    )
+    chunks = chunker.chunk_text(PYTHON_CODE, include_comments=include_comments)
     content = "\n".join(chunk.content for chunk in chunks)
 
     # Use correct case and exact comment text from fixture
@@ -293,19 +288,15 @@ def test_broken_token_counter():
     def broken_token_counter(text: str) -> int:
         raise ValueError("Token counter failed")
 
-    chunker = CodeChunker(token_counter=broken_token_counter)
+    chunker = CodeChunker(token_counter=broken_token_counter, max_tokens=30)
     with pytest.raises(CallbackError):  # Should raise from the broken token counter
-        chunker.chunk_text("def test(): pass", max_tokens=30)
+        chunker.chunk_text("def test(): pass")
 
 
 def test_missing_token_counter_error():
     """Test MissingTokenCounterError when token counter is required but not provided."""
-    new_chunker = CodeChunker()  # chunker without a token counter
     with pytest.raises(MissingTokenCounterError):
-        new_chunker.chunk_text(
-            "def test(): pass",
-            max_tokens=30,
-        )
+        CodeChunker(max_tokens=30)
 
 
 @pytest.mark.parametrize(
@@ -317,10 +308,8 @@ def test_missing_token_counter_error():
 )
 def test_invalid_constraints_error(max_tokens, max_lines, max_functions):
     """Test InvalidInputError for invalid constraint combinations."""
-    new_chunker = CodeChunker()  # chunker without a token counter
     with pytest.raises(InvalidInputError):
-        new_chunker.chunk_text(
-            "def test(): pass",
+        CodeChunker(
             max_tokens=max_tokens,
             max_lines=max_lines,
             max_functions=max_functions,
@@ -329,8 +318,8 @@ def test_invalid_constraints_error(max_tokens, max_lines, max_functions):
 
 def test_empty_source_code():
     """Test that empty source code returns empty list."""
-    chunker = CodeChunker()
-    result = chunker.chunk_text("", max_lines=30)
+    chunker = CodeChunker(max_lines=30)
+    result = chunker.chunk_text("")
     assert result == []
 
 
@@ -338,13 +327,13 @@ def test_code_chunker_with_file(tmp_path):
     """Test CodeChunker with temporary files - both valid Python and binary."""
     from chunklet import FileProcessingError
 
-    chunker = CodeChunker(token_counter=simple_token_counter)
+    chunker = CodeChunker(token_counter=simple_token_counter, max_tokens=50)
 
     # Test 1: Valid Python file
     python_file = tmp_path / "test_code.py"
     python_file.write_text(PYTHON_CODE)
 
-    chunks = chunker.chunk_file(python_file, max_tokens=50)
+    chunks = chunker.chunk_file(python_file)
     assert len(chunks) > 0
     assert all(chunk.metadata.start_line <= chunk.metadata.end_line for chunk in chunks)
 
@@ -353,28 +342,28 @@ def test_code_chunker_with_file(tmp_path):
     binary_file.write_bytes(b"\x00\x01\x02\x03\xff\xfe\xfd\xfc")  # Binary data
 
     with pytest.raises(FileProcessingError, match="Binary file not supported"):
-        chunker.chunk_file(binary_file, max_tokens=50)
+        chunker.chunk_file(binary_file)
 
 
 def test_nonexistent_file(chunker):
     """Test Error For Non-Existent File."""
     with pytest.raises(FileProcessingError):
-        chunker.chunk_file(NON_EXISTENT_FILE, max_tokens=30)
+        chunker.chunk_file(NON_EXISTENT_FILE)
 
 
 def test_oversized_block_error(chunker):
     """Test Error For Blocks Exceeding Max Tokens."""
-    params = {
-        "code": LONG_FUNCTION_CODE,
-        "max_tokens": 30,
-        "max_lines": 5,
-        "max_functions": 1,
-    }
+    chunker_strict = CodeChunker(
+        token_counter=simple_token_counter,
+        max_tokens=30,
+        max_lines=5,
+        max_functions=1,
+    )
     with pytest.raises(TokenLimitError):
-        chunker.chunk_text(**params, strict=True)
+        chunker_strict.chunk_text(LONG_FUNCTION_CODE, strict=True)
 
-    # should not raise on strict mode is disabled
-    chunks = chunker.chunk_text(**params, strict=False)
+    # should not raise when strict mode is disabled
+    chunks = chunker_strict.chunk_text(LONG_FUNCTION_CODE, strict=False)
     assert len(chunks) > 0  # Should split into multiple chunks
 
 
@@ -385,10 +374,11 @@ def test_batch_chunk_success(chunker):
     """Test successful batch processing of multiple sources."""
     separator = object()
 
+    chunker = CodeChunker(token_counter=simple_token_counter, max_tokens=50)
+
     results = list(
         chunker.chunk_texts(
             MULTIPLE_SOURCES,
-            max_tokens=50,
             on_errors="skip",
             separator=separator,
         )
@@ -412,10 +402,11 @@ def test_batch_chunk_success(chunker):
 def test_batch_chunk_different_max_tokens(max_tokens, chunker):
     """Test batch processing with different max_tokens values."""
 
+    chunker = CodeChunker(token_counter=simple_token_counter, max_tokens=max_tokens)
+
     chunks = list(
         chunker.chunk_texts(
             MULTIPLE_SOURCES,
-            max_tokens=max_tokens,
         )
     )
 
@@ -428,6 +419,8 @@ def test_batch_chunk_different_max_tokens(max_tokens, chunker):
 
 def test_batch_chunk_error_handling_on_task(chunker):
     """Test the on_errors parameter in chunk_texts."""
+
+    chunker = CodeChunker(token_counter=simple_token_counter, max_tokens=50)
 
     # Create a temp file for testing
     with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
@@ -442,16 +435,13 @@ def test_batch_chunk_error_handling_on_task(chunker):
             list(
                 chunker.chunk_files(
                     sources_with_error,
-                    max_tokens=50,
                     on_errors="raise",
                     show_progress=False,
                 )
             )
 
         # Test on_errors = 'skip'
-        chunks = list(
-            chunker.chunk_files(sources_with_error, max_tokens=50, on_errors="skip")
-        )
+        chunks = list(chunker.chunk_files(sources_with_error, on_errors="skip"))
         assert len(chunks) > 0
     finally:
         os.unlink(valid_file)

--- a/tests/test_document_chunking.py
+++ b/tests/test_document_chunking.py
@@ -15,7 +15,7 @@ from chunklet.document_chunker import CustomProcessorRegistry, DocumentChunker
 @pytest.fixture
 def chunker():
     """Provides a DocumentChunker instance."""
-    return DocumentChunker()
+    return DocumentChunker(max_sentences=5)
 
 
 @pytest.fixture
@@ -27,7 +27,7 @@ def registry():
 @pytest.fixture
 def chunker_with_registry(registry):
     """Provides a DocumentChunker bound to the fresh registry."""
-    return DocumentChunker(processor_registry=registry)
+    return DocumentChunker(processor_registry=registry, max_sentences=5)
 
 
 # --- Core Tests ---
@@ -44,7 +44,7 @@ def chunker_with_registry(registry):
 )
 def test_chunk_simple_files(chunker, path):
     """Test the main chunk method with various supported file types."""
-    chunks = chunker.chunk_file(path, max_sentences=5)
+    chunks = chunker.chunk_file(path)
     assert len(chunks) > 0
     assert "source" in chunks[0].metadata
 
@@ -72,7 +72,7 @@ def test_batch_chunk_with_different_file_type(chunker):
         "samples/Free_Test_Data_100KB_PPTX.pptx",
         "samples/Sample.tex",
     ]
-    all_document_chunks = list(chunker.chunk_files(paths, max_sentences=5))
+    all_document_chunks = list(chunker.chunk_files(paths))
 
     # Check that we got some chunks
     assert len(all_document_chunks) > 0
@@ -102,13 +102,15 @@ def test_chunk_method_unsupported_iterable_processor(chunker):
             "💡 Hint: use `chunker.chunk_files([file.ext])` for this file type."
         ),
     ):
-        chunker.chunk_file("samples/sample-pdf-a4-size.pdf", max_sentences=5)
+        chunker.chunk_file("samples/sample-pdf-a4-size.pdf")
 
 
 # --- Custom Processor Tests ---
 
 
-def test_chunk_method_with_custom_processor(tmp_path, mocker, chunker_with_registry, registry):
+def test_chunk_method_with_custom_processor(
+    tmp_path, mocker, chunker_with_registry, registry
+):
     """Test that the chunk method correctly uses a custom processor."""
 
     # Define and register a mock custom processor callback
@@ -124,7 +126,7 @@ def test_chunk_method_with_custom_processor(tmp_path, mocker, chunker_with_regis
         )
 
         # Chunk the dummy file
-        chunks = chunker_with_registry.chunk_file(dummy_file, max_sentences=5)
+        chunks = chunker_with_registry.chunk_file(dummy_file)
 
         # Assert that the custom processor's output was used
         expected_content_prefix = "Processed failed."
@@ -174,13 +176,15 @@ def test_custom_processor_validation_scenarios(
 
     try:
         with pytest.raises(CallbackError, match=re.escape(expected_match)):
-            chunker_with_registry.chunk_file(dummy_file, max_sentences=5)
+            chunker_with_registry.chunk_file(dummy_file)
     finally:
         # Unregister to not affect other tests
         registry.unregister(".txt")
 
 
-def test_batch_chunk_custom_processor_error_handling(chunker_with_registry, registry, tmp_path):
+def test_batch_chunk_custom_processor_error_handling(
+    chunker_with_registry, registry, tmp_path
+):
     """Test batch_chunk error handling with failing custom processor."""
     # Create test files with different extensions
     file1 = tmp_path / "test1.txt"  # Will use failing processor
@@ -195,19 +199,17 @@ def test_batch_chunk_custom_processor_error_handling(chunker_with_registry, regi
     try:
         # Test on_errors="raise" - should re-raise
         with pytest.raises(CallbackError):
-            list(
-                chunker_with_registry.chunk_files([file1, file2], max_sentences=5, on_errors="raise")
-            )
+            list(chunker_with_registry.chunk_files([file1, file2], on_errors="raise"))
 
         # Test on_errors="skip" - should skip failed file, process .md file
         chunks = list(
-            chunker_with_registry.chunk_files([file1, file2], max_sentences=5, on_errors="skip")
+            chunker_with_registry.chunk_files([file1, file2], on_errors="skip")
         )
         assert len(chunks) >= 1  # Should get chunks from successful .md file
 
         # Test on_errors="break" - should stop on first error (txt file)
         chunks = list(
-            chunker_with_registry.chunk_files([file1, file2], max_sentences=5, on_errors="break")
+            chunker_with_registry.chunk_files([file1, file2], on_errors="break")
         )
         assert len(chunks) == 0  # Should get no chunks since txt fails first
 

--- a/tests/test_plain_text_chunking.py
+++ b/tests/test_plain_text_chunking.py
@@ -53,11 +53,12 @@ def chunker():
 
 
 def test_init_validation_error():
-    """Test that InvalidInputError is raised for invalid initialization parameters."""
+    """Test that InvalidInputError is raised when no chunking limit is provided."""
     with pytest.raises(
-        InvalidInputError, match=re.escape("(token_counter) Input should be callable.")
+        InvalidInputError,
+        match="At least one of 'max_tokens', 'max_sentences', or 'max_section_breaks'",
     ):
-        DocumentChunker(token_counter="Not a callable")
+        DocumentChunker()
 
 
 @pytest.mark.parametrize(
@@ -282,25 +283,18 @@ def test_batch_processing_successful(chunker, texts_input, expected_results_len)
 
 def test_batch_processing_input_validation(chunker):
     """Test batch processing error handling on invalid input"""
-    # Test that InvalidInputError is raised for input that is an iterable, but contains wrong types
-    texts_input_int = [1, 2, 3]  # Use list[int] here
-
-    chunker = DocumentChunker(
-        token_counter=chunker.token_counter,
-        max_sentences=1,
-    )
-
-    with pytest.raises(
-        InvalidInputError, match=re.escape("Input should be a valid string.")
-    ):
-        list(chunker.chunk_texts(texts_input_int))
-
-    # Test n_jobs with an invalid type
+    # n_jobs is validated at the DocumentChunker boundary.
     with pytest.raises(
         InvalidInputError,
         match=re.escape("(n_jobs) Input should be greater than or equal to 1."),
     ):
         list(chunker.chunk_texts(["some text"], n_jobs=-1))
+
+    # Non-string items in the iterable are not validated at the boundary
+    # (IterableOfStr is shallow); they reach the batch runner and raise
+    # a TypeError when processed as strings.
+    with pytest.raises(TypeError):
+        list(chunker.chunk_texts([1, 2, 3]))
 
 
 def test_batch_chunk_error_handling_on_task(chunker):

--- a/tests/test_plain_text_chunking.py
+++ b/tests/test_plain_text_chunking.py
@@ -43,7 +43,10 @@ def chunker():
             raise ValueError("Intentional failure")
         return len(text.split())
 
-    return DocumentChunker(token_counter=simple_token_counter)
+    return DocumentChunker(
+        token_counter=simple_token_counter,
+        max_sentences=100,
+    )
 
 
 # --- Core Tests ---
@@ -70,12 +73,13 @@ def test_constraint_based_chunking(
     chunker, max_tokens, max_sentences, max_section_breaks, expected_chunks
 ):
     """Verify constraint-based chunking produces output with expected chunk counts and structure."""
-    chunks = chunker.chunk_text(
-        TEXT,
+    chunker = DocumentChunker(
+        token_counter=chunker.token_counter,
         max_tokens=max_tokens,
         max_sentences=max_sentences,
         max_section_breaks=max_section_breaks,
     )
+    chunks = chunker.chunk_text(TEXT)
     assert chunks, "Expected chunks but got empty list"
     assert len(chunks) == expected_chunks, (
         f"Expected {expected_chunks} chunks, but got {len(chunks)}"
@@ -134,7 +138,12 @@ def test_constraint_based_chunking(
 )
 def test_offset_behavior(chunker, offset, expect_chunks):
     """Verify offset affects output and large offsets produce no chunks"""
-    chunks = chunker.chunk_text(TEXT, offset=offset, max_sentences=3)
+    chunker = DocumentChunker(
+        token_counter=chunker.token_counter,
+        max_sentences=3,
+        offset=offset,
+    )
+    chunks = chunker.chunk_text(TEXT)
 
     if expect_chunks:
         assert len(chunks) >= 1, f"Should get chunks for offset={offset}"
@@ -146,16 +155,17 @@ def test_offset_behavior(chunker, offset, expect_chunks):
 def test_token_counter_validation():
     """Test that a MissingTokenCounterError is raised when a token_counter is missing for token/hybrid modes."""
     with pytest.raises(MissingTokenCounterError):
-        new_chunker = DocumentChunker()
-
-        # Consume the generator to trigger the error
-        new_chunker.chunk_text("some text", max_tokens=30)
+        DocumentChunker(max_tokens=30)
 
 
 def test_long_sentence_truncation(chunker):
     """Test that a long sentence without punctuation is #truncated correctly."""
     long_sentence = "word " * 100
-    chunks = chunker.chunk_text(long_sentence, max_tokens=30)
+    chunker = DocumentChunker(
+        token_counter=chunker.token_counter,
+        max_tokens=30,
+    )
+    chunks = chunker.chunk_text(long_sentence)
 
     assert len(chunks) >= 1, "Expected at least one chunk, but got None"
     assert chunks[0].content.endswith("..."), (
@@ -169,11 +179,12 @@ def test_long_sentence_truncation(chunker):
 def test_overlap_behavior(chunker):
     """Test that overlap produces multiple chunks and the overlap content is correct."""
 
-    chunks = chunker.chunk_text(
-        TEXT,
+    chunker = DocumentChunker(
+        token_counter=chunker.token_counter,
         max_sentences=4,
         overlap_percent=50,
     )
+    chunks = chunker.chunk_text(TEXT)
     assert len(chunks) > 1, "Overlap should produce multiple chunks"
 
     # Expected that about 50% of first chunk content is present in the second one
@@ -251,10 +262,13 @@ def test_span_finder(text: str, query: str, expected: tuple[int, int]):
 )
 def test_batch_processing_successful(chunker, texts_input, expected_results_len):
     """Comprehensive test for batch processing successful runs and edge cases."""
+    chunker = DocumentChunker(
+        token_counter=chunker.token_counter,
+        max_sentences=100,
+    )
     results = list(
         chunker.chunk_texts(
             texts_input,
-            max_sentences=100,
             separator=SEPARATOR_SENTINEL,
         )
     )
@@ -271,23 +285,33 @@ def test_batch_processing_input_validation(chunker):
     # Test that InvalidInputError is raised for input that is an iterable, but contains wrong types
     texts_input_int = [1, 2, 3]  # Use list[int] here
 
+    chunker = DocumentChunker(
+        token_counter=chunker.token_counter,
+        max_sentences=1,
+    )
+
     with pytest.raises(
         InvalidInputError, match=re.escape("Input should be a valid string.")
     ):
-        list(chunker.chunk_texts(texts_input_int, max_sentences=1))
+        list(chunker.chunk_texts(texts_input_int))
 
     # Test n_jobs with an invalid type
     with pytest.raises(
         InvalidInputError,
         match=re.escape("(n_jobs) Input should be greater than or equal to 1."),
     ):
-        list(chunker.chunk_texts(["some text"], n_jobs=-1, max_sentences=1))
+        list(chunker.chunk_texts(["some text"], n_jobs=-1))
 
 
 def test_batch_chunk_error_handling_on_task(chunker):
     """Test the on_errors parameter in chunk_texts."""
 
     texts = ["This is ok.", "This will fail.", "This will not be processed."]
+
+    chunker = DocumentChunker(
+        token_counter=chunker.token_counter,
+        max_tokens=12,
+    )
 
     # Test on_errors = 'raise'
     with pytest.raises(
@@ -297,7 +321,6 @@ def test_batch_chunk_error_handling_on_task(chunker):
         list(
             chunker.chunk_texts(
                 texts,
-                max_tokens=12,
                 on_errors="raise",
                 show_progress=False,  # Disabled to prevent an unexpected hanging
             )
@@ -306,7 +329,6 @@ def test_batch_chunk_error_handling_on_task(chunker):
     # Test on_errors = 'skip'
     results = chunker.chunk_texts(
         texts,
-        max_tokens=12,
         on_errors="skip",
         separator=SEPARATOR_SENTINEL,
     )
@@ -321,7 +343,6 @@ def test_batch_chunk_error_handling_on_task(chunker):
     # Test on_errors = 'break'
     results = chunker.chunk_texts(
         texts,
-        max_tokens=12,
         on_errors="break",
         separator=SEPARATOR_SENTINEL,
     )

--- a/tests/test_plain_text_chunking.py
+++ b/tests/test_plain_text_chunking.py
@@ -212,7 +212,8 @@ def test_split_sentence_remnant_is_not_duplicated(chunker):
     In conclusion, mastering chunking is key to unlocking the full potential of your text data.
     """)
 
-    chunks = chunker.chunk_text(text, max_tokens=50)
+    chunker.max_tokens = 50
+    chunks = chunker.chunk_text(text)
 
     # Every chunk must resolve to a real span in the source text.
     for chunk in chunks:

--- a/tests/test_sentence_splitting.py
+++ b/tests/test_sentence_splitting.py
@@ -37,7 +37,7 @@ def splitter():
 )
 def test_multilingual_splitting(splitter, text, expected_sentences):
     """Test sentence splitting for various languages but not limited to."""
-    sentences = splitter.split_text(text, lang="auto")
+    sentences = splitter.split_text(text)
     assert sentences == expected_sentences
 
 
@@ -48,9 +48,10 @@ def test_multilingual_splitting(splitter, text, expected_sentences):
         ("Sawubona Mhlaba. Unjani?", "zu"),  # Zulu
     ],
 )
-def test_unsupported_language_fallback(splitter, text, lang):
+def test_unsupported_language_fallback(text, lang):
     """Test fallback to universal regex splitter for unsupported languages."""
-    sentences = splitter.split_text(text, lang)
+    splitter = SentenceSplitter(lang=lang)
+    sentences = splitter.split_text(text)
     assert len(sentences) >= 1
 
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -43,7 +43,9 @@ def _multipart_post(
     request_headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
     request_headers.update(headers or {})
     return urllib.request.urlopen(
-        urllib.request.Request(url, data=bytes(body), headers=request_headers, method="POST"),
+        urllib.request.Request(
+            url, data=bytes(body), headers=request_headers, method="POST"
+        ),
         timeout=10,
     )
 


### PR DESCRIPTION
## Summary

Chunker sizing and tuning parameters are now configured once at construction (`__init__`) instead of being passed per call. This makes chunking constraints explicit, immutable-at-call-site configuration, and cleans up the per-call signatures so only genuinely per-invocation inputs (token counter, metadata, batch orchestration) are passed in.

## What Changed

- **Document / PlainText chunkers**: `max_tokens`, `max_sentences`, `max_section_breaks`, `overlap_percent`, `offset`, and `lang` moved from `chunk_text`/`chunk_texts`/`chunk_file`/`chunk_files` into the constructor.
- **Remove redundant validation**: remove @validate_input and simplify Annotated hints in PlainTextChunker
- **Code chunker**: `max_tokens`, `max_lines`, `max_functions` moved into the constructor; `strict`/`docstring_mode`/`include_comments` remain per-call.
- **Sentence splitter**: `lang` moved into the constructor for both `split_text` and `split_file`.
- **Constraints are now mutable attributes**: `DocumentChunker` delegates them to its internal plain-text chunker, and mutating a validated constraint re-runs validation. The web visualizer and CLI instantiate shared chunkers with defaults and set/override these attributes per request.

## Testing

- Full suite passes (77 tests), including updated tests for the moved `lang`/constraint args.
- Ruff lint + format clean (`src/`, `tests/`).
- Exercised CLI `chunk` and `split` end-to-end (with and without `--lang`) and the visualizer's per-request constraint mutation.

## Risk / Rollout

- **Feature-flagged**: No.
- **Migration required**: Breaking — callers must move the renamed params from the chunking methods into the constructor. A migration guide and checker update are in progress as a follow-up.
- **Revert**: Revert the branch.

## Notes for Reviewers

- The per-call `chunk_kwargs` bundling in the CLI is retained intentionally to keep the three call sites (`chunk_text`/`chunk_file`/`chunk_files`) uniform across code and document modes.
- `lang` defaults to `"auto"`, so batch behavior for per-document language detection is preserved even though `lang` now lives at init.