### PR TITLE
Fix token-limited chunking bug causing duplicated clauses and unresolved spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0] - Unreleased
 
+### Fixed
+- **Plain text chunker**: When a sentence is split mid-way on the token limit, its unfitted remainder now opens the next chunk instead of the full sentence being re-appended on top of the overlap clause. Fixes duplicated clauses and unresolved `(-1, -1)` spans in token-limited chunking.
+
 ### Removed
 - **Deprecated APIs**: Removed the aliases deprecated in v2.2.0 ahead of the v3.0.0 release:
   - `chunk()` and `batch_chunk()` from `DocumentChunker` and `CodeChunker`

--- a/src/chunklet/document_chunker/_plain_text_chunker.py
+++ b/src/chunklet/document_chunker/_plain_text_chunker.py
@@ -336,6 +336,7 @@ class PlainTextChunker:
             ):
                 # for token-based mode, try splitting further
                 unfitted = ""
+                has_remnant = False
                 if token_limit_reached:
                     remaining_tokens = max_tokens - constraint_counter["token_count"]
                     fitted, unfitted = self._find_clauses_that_fit(
@@ -365,6 +366,7 @@ class PlainTextChunker:
                     if unfitted:
                         # We need to process the remnants separately
                         sentences[index] = unfitted
+                        has_remnant = True
 
                 chunks.append("\n".join(curr_chunk))  # Considered complete
 
@@ -377,6 +379,12 @@ class PlainTextChunker:
                     token_counter=token_counter,
                     constraint_counter=constraint_counter,
                 )
+
+                if has_remnant:
+                    # The sentence was split; its unfitted remnant was stored
+                    # at sentences[index]. Process it as the start of the new
+                    # chunk instead of re-appending the full original sentence.
+                    continue
 
             curr_chunk.append(sentence)
             constraint_counter["token_count"] += sentence_tokens

--- a/tests/test_plain_text_chunking.py
+++ b/tests/test_plain_text_chunking.py
@@ -1,6 +1,7 @@
 import re
 
 import pytest
+from textwrap import dedent
 from more_itertools import split_at
 
 from chunklet import (
@@ -180,6 +181,33 @@ def test_overlap_behavior(chunker):
     assert all([cls.strip() in chunks[1].content for cls in expected_overlap]), (
         f"Expected second chunk to start with '{expected_overlap}'."
     )
+
+
+def test_split_sentence_remnant_is_not_duplicated(chunker):
+    """Regression: splitting a sentence on the token limit re-appended the full
+    sentence on top of the overlap clause, duplicating content and producing
+    (-1, -1) spans. The unfitted remnant must open the next chunk instead."""
+
+    text = dedent("""### Different Strategies
+
+    There are several strategies for chunking, including splitting by sentences, by a fixed number of tokens, or by structural elements like headings.
+    Each method has its own advantages depending on the specific use case.
+
+    ---
+
+    # Conclusion
+
+    In conclusion, mastering chunking is key to unlocking the full potential of your text data.
+    """)
+
+    chunks = chunker.chunk_text(text, max_tokens=50)
+
+    # Every chunk must resolve to a real span in the source text.
+    for chunk in chunks:
+        assert chunk.metadata["span"] != (-1, -1), (
+            f"Chunk {chunk.metadata['chunk_num']} has an unresolved span: "
+            f"{chunk.content!r}"
+        )
 
 
 # --- Span Finder Tests ---


### PR DESCRIPTION
## Summary

Fixes a token-limited chunking bug where a sentence split mid-way was re-appended in full to the next chunk, duplicating the split clause and yielding `(-1, -1)` spans.

## What Changed

- After splitting a sentence on the token budget, the unfitted remainder now opens the next chunk instead of the original full sentence being appended on top of the overlap clause.
- Chunks emitted by token-limited chunking now always resolve to real spans in the source text.

## Testing

- Added regression test `test_split_sentence_remnant_is_not_duplicated` covering the duplicated-clause and unresolved-span cases; it fails on the pre-fix code.
- Full suite: 71 tests pass; `ruff check` and `ruff format --check` clean on the touched file.

## Notes for Reviewers

- The fix is a `continue` after the next-chunk is prepared, so the stored remnant at `sentences[index]` is re-processed rather than the pre-split sentence.