### PR TITLE
Fix heading span start to include `#` in chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Plain text chunker**: When a sentence is split mid-way on the token limit, its unfitted remainder now opens the next chunk instead of the full sentence being re-appended on top of the overlap clause. Fixes duplicated clauses and unresolved `(-1, -1)` spans in token-limited chunking.
+- **Span finder**: The normalized search keeps `#` from Markdown headings, so a chunk starting with a heading reports a span that includes the heading marker instead of starting after it.
 
 ### Removed
 - **Deprecated APIs**: Removed the aliases deprecated in v2.2.0 ahead of the v3.0.0 release:

--- a/src/chunklet/document_chunker/span_finder.py
+++ b/src/chunklet/document_chunker/span_finder.py
@@ -33,7 +33,7 @@ class DeterministicSpanFinder:
         chars = []
 
         for i, ch in enumerate(text):
-            if ch.isalnum():
+            if ch.isalnum() or ch == "#":
                 chars.append(ch)
                 index_map[curr_idx] = i
                 curr_idx += 1
@@ -60,7 +60,7 @@ class DeterministicSpanFinder:
         if (start := self.full_text.find(stripped)) != -1:
             return start, start + len(stripped)
 
-        cleaned_text = "".join(ch for ch in text if ch.isalnum())
+        cleaned_text = "".join(ch for ch in text if ch.isalnum() or ch == "#")
 
         pos = self.cleaned_full_text.find(cleaned_text)
         if pos != -1:

--- a/tests/test_plain_text_chunking.py
+++ b/tests/test_plain_text_chunking.py
@@ -18,8 +18,7 @@ from chunklet.sentence_splitter import SentenceSplitter
 # Sentinel to serve as boundary between the groups of chunks for each text
 SEPARATOR_SENTINEL = object()
 
-TEXT = """
-# A weird dream
+TEXT = """# A weird dream
 
 She loves cooking. He studies AI. "You are a Dr.", she said. The weather is great. We play chess. Books are fun, aren't they?
 
@@ -84,6 +83,7 @@ def test_constraint_based_chunking(
 
     # Verify the structure of the first chunk
     first_chunk = chunks[0]
+    assert first_chunk.metadata.span[0] == 0
     assert hasattr(first_chunk, "content")
     assert hasattr(first_chunk, "metadata")
     assert len(first_chunk.content) > 0


### PR DESCRIPTION
## Summary

When a chunk starts with a Markdown heading, the span lookup dropped the `#` from the normalized search, so `# Introduction to Chunking` was reported as starting at "Introduction" (index 2) instead of at the heading marker (index 0). The normalized search now keeps `#`, so heading-leading chunks span the full heading.

## What Changed

- `DeterministicSpanFinder` preserves `#` (in addition to alphanumerics) when building its cleaned text and index map, so spans include the heading marker.

## Testing

- Updated the chunking test fixture to remove the leading newline and assert the first chunk's `span[0] == 0`.
- Span-finder and constraint-based chunking tests pass (10/10); full plain-text + document chunking suites pass (35).

## Notes for Reviewers

- The normalized path's `end` index is still approximate (it counts cleaned chars, not original positions); this PR only fixes the `#` drop. Making `end` fully exact is a separate change.