### PR TITLE
Documents: Update Init Constraints in APIs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -21,7 +21,7 @@ changelog:
         - python
         - optimization
         - breaking-changes
-       
+
     - title: '🐛 Fixed'
       labels:
         - bug

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -21,7 +21,7 @@ changelog:
         - python
         - optimization
         - breaking-changes
-        
+       
     - title: '🐛 Fixed'
       labels:
         - bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0] - Unreleased
 
+### Changed
+- **Chunker constraints moved to the constructor**: Sizing/tuning parameters are now set at `__init__` instead of per call:
+  - `DocumentChunker` / `PlainTextChunker`: `max_tokens`, `max_sentences`, `max_section_breaks`, `overlap_percent`, `offset`, and `lang` are now set at construction instead of passed to `chunk_text` / `chunk_texts` / `chunk_file` / `chunk_files`.
+  - `CodeChunker`: `max_tokens`, `max_lines`, and `max_functions` are now set at construction. `strict`, `docstring_mode`, and `include_comments` remain per-call.
+  - `SentenceSplitter`: `lang` is now set at construction; `split_text` / `split_file` no longer accept it.
+- **Mutability**: Constraints are now plain attributes on the chunker. Mutating a validated constraint (e.g., `chunker.max_sentences = 4`) re-runs constraint validation, and `DocumentChunker` delegates these attributes to its internal plain-text chunker.
+
 ### Fixed
-- **Plain text chunker**: When a sentence is split mid-way on the token limit, its unfitted remainder now opens the next chunk instead of the full sentence being re-appended on top of the overlap clause. Fixes duplicated clauses and unresolved `(-1, -1)` spans in token-limited chunking.
+- **Plain text chunker**: When a sentence is split mid-way on the token limit, its unfitted remainder now opens the n
+ext chunk instead of the full sentence being re-appended on top of the overlap clause. Fixes duplicated clauses and unresolved `(-1, -1)` spans in token-limited chunking.
 - **Span finder**: The normalized search keeps `#` from Markdown headings, so a chunk starting with a heading reports a span that includes the heading marker instead of starting after it.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Mutability**: Constraints are now plain attributes on the chunker. Mutating a validated constraint (e.g., `chunker.max_sentences = 4`) re-runs constraint validation, and `DocumentChunker` delegates these attributes to its internal plain-text chunker.
 
 ### Fixed
-- **Plain text chunker**: When a sentence is split mid-way on the token limit, its unfitted remainder now opens the n
-ext chunk instead of the full sentence being re-appended on top of the overlap clause. Fixes duplicated clauses and unresolved `(-1, -1)` spans in token-limited chunking.
+- **Plain text chunker**: When a sentence is split mid-way on the token limit, its unfitted remainder now opens the next chunk instead of the full sentence being re-appended on top of the overlap clause. Fixes duplicated clauses and unresolved `(-1, -1)` spans in token-limited chunking.
 - **Span finder**: The normalized search keeps `#` from Markdown headings, so a chunk starting with a heading reports a span that includes the heading marker instead of starting after it.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ Chunklet-py is basically a "choose your own adventure" for data. It's constraint
 Pick your weapon based on whatever data mess you're currently cleaning up.
 
 ```python
-from chunklet import DocumentChunker   # For PDFs, DOCX, and general text chaos
-from chunklet import CodeChunker       # For source code (it actually respects brackets)
+from chunklet import DocumentChunker  # For PDFs, DOCX, and general text chaos
+from chunklet import CodeChunker  # For source code (it actually respects brackets)
 from chunklet import SentenceSplitter  # For when you just need to split sentences
-from chunklet import visualizer        # Web-based chunk visualizer
+from chunklet import visualizer  # Web-based chunk visualizer
 ```
 
 ### Configuration & Limits
@@ -211,11 +211,11 @@ chunker = DocumentChunker()
 # Feel free to mix and match these
 chunks = chunker.chunk_text(
     text,
-    max_sentences=3,       # Stop after X sentences
-    max_tokens=500,        # Don't blow up the LLM context
+    max_sentences=3,  # Stop after X sentences
+    max_tokens=500,  # Don't blow up the LLM context
     max_section_breaks=2,  # Respect the Markdown headers
-    overlap_percent=20,    # Give it some "memory" of the last chunk
-    offset=0               # Skip the first N sentences if you're feeling adventurous
+    overlap_percent=20,  # Give it some "memory" of the last chunk
+    offset=0,  # Skip the first N sentences if you're feeling adventurous
 )
 ```
 
@@ -229,10 +229,10 @@ chunker = CodeChunker()
 # Again, use whichever constraints make sense for your file
 chunks = chunker.chunk_text(
     text,
-    max_lines=50,          # Height limit
-    max_tokens=512,        # Width limit
-    max_functions=1,       # One function per chunk (keeps things tidy)
-    strict=True            # True: Crash on big blocks; False: Slice 'em up anyway
+    max_lines=50,  # Height limit
+    max_tokens=512,  # Width limit
+    max_functions=1,  # One function per chunk (keeps things tidy)
+    strict=True,  # True: Crash on big blocks; False: Slice 'em up anyway
 )
 ```
 
@@ -242,9 +242,9 @@ The chunkers return a list (or generator) of Chunk objects. These are Box instan
 
 ```python
 for chunk in chunks:
-    print(chunk.content)   # The actual text/code
+    print(chunk.content)  # The actual text/code
     print(chunk.metadata)  # Chunk metadata
-    print()                # Because whitespace is free
+    print()  # Because whitespace is free
 ```
 
 ### Input Methods (Chunkers Only)

--- a/audit_migration.py
+++ b/audit_migration.py
@@ -19,6 +19,17 @@ REMOVED_ARGUMENTS = {
     ),
 }
 
+MOVED_TO_CONSTRUCTOR = {
+    "max_tokens": "Move to the constructor: `Chunker(max_tokens=...)`.",
+    "max_sentences": "Move to the constructor: `Chunker(max_sentences=...)`.",
+    "max_section_breaks": "Move to the constructor: `Chunker(max_section_breaks=...)`.",
+    "overlap_percent": "Move to the constructor: `Chunker(overlap_percent=...)`.",
+    "offset": "Move to the constructor: `Chunker(offset=...)`.",
+    "lang": "Move to the constructor: `Chunker(lang=...)`.",
+    "max_lines": "Move to the constructor: `CodeChunker(max_lines=...)`.",
+    "max_functions": "Move to the constructor: `CodeChunker(max_functions=...)`.",
+}
+
 CHUNKER_CLASS_NAMES = {"Chunklet", "PlainTextChunker", "DocumentChunker", "CodeChunker"}
 
 LEGACY_IMPORTS = {
@@ -200,19 +211,36 @@ class MigrationAuditor:
                         )
 
     def _audit_removed_arguments(self, file_path: Path, tree: ast.AST, lines: list[str]):
-        """Flag keyword arguments removed in v2/v3."""
+        """Flag keyword arguments removed in v2/v3 or moved to the constructor."""
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
-            for kw in node.keywords:
-                if kw.arg in REMOVED_ARGUMENTS:
-                    self._has_legacy_issues = True
+            moved_args = [
+                kw.arg for kw in node.keywords
+                if kw.arg in MOVED_TO_CONSTRUCTOR
+            ]
+            removed_args = [
+                kw.arg for kw in node.keywords
+                if kw.arg in REMOVED_ARGUMENTS
+            ]
+            if moved_args:
+                self._has_legacy_issues = True
+                self._print_issue(
+                    file_path,
+                    node.lineno,
+                    self._get_line(lines, node.lineno),
+                    f"Move to constructor: {', '.join(moved_args)}",
+                    "yellow",
+                )
+            if removed_args:
+                self._has_legacy_issues = True
+                for arg in removed_args:
                     self._print_issue(
                         file_path,
                         node.lineno,
                         self._get_line(lines, node.lineno),
-                        f"Argument '{kw.arg}' no longer has that meaning. "
-                        f"{REMOVED_ARGUMENTS[kw.arg]}",
+                        f"'{arg}' no longer has that meaning. "
+                        f"{REMOVED_ARGUMENTS[arg]}",
                         "bold red",
                     )
 

--- a/docs/getting-started/programmatic/code_chunker.md
+++ b/docs/getting-started/programmatic/code_chunker.md
@@ -684,6 +684,11 @@ for i, chunk in enumerate(chunks):
     Chunking ...: 100%|██████████| 4/4 [00:00, 12.45it/s]
     ```
 
+!!! note "Non-Deterministic Batch Ordering"
+    When using `chunk_files` or `chunk_texts` with parallel processing (`n_jobs > 1`), chunks from different files are processed concurrently by multiple worker processes. The order in which chunks are yielded depends on which worker finishes first, which varies with system load and scheduling. So the overall ordering of chunks across files is not guaranteed to be stable between runs. The `chunk_num` field within each chunk's metadata still reflects the chunk's position within its source file.
+
+    When using the `separator` parameter, the separator-based grouping is deterministic even with parallel processing.
+
 !!! warning "Generator Cleanup"
     When using `chunk_files`, it's crucial to ensure the generator is properly closed, especially if you don't iterate through all the chunks. This is necessary to release the underlying multiprocessing resources. The recommended way is to use a `try...finally` block to call `close()` on the generator. For more details, see the [Troubleshooting](../../troubleshooting.md) guide.
 

--- a/docs/getting-started/programmatic/code_chunker.md
+++ b/docs/getting-started/programmatic/code_chunker.md
@@ -55,13 +55,9 @@ Let's see `CodeChunker` in action with a single code input. It provides two meth
 - `chunk_text()` - accepts raw code as a string
 - `chunk_file()` - accepts a file path as a string or `pathlib.Path` object
 
-### Chunking by Lines: Line Count Control! 📏
+Let's say you have
 
-Ready to chunk code by line count? This gives you predictable, size-based chunks:
-
-``` py linenums="1"
-from chunklet.code_chunker import CodeChunker
-
+```py
 PYTHON_CODE = '''
 """
 Module docstring
@@ -93,17 +89,20 @@ def standalone_function():
     """A standalone function."""
     return True
 '''
+```
 
-# Helper function
-def simple_token_counter(text: str) -> int:
-    """Simple Token Counter For Testing."""
-    return len(text.split())
+### Chunking by Lines: Line Count Control! 📏
 
-chunker = CodeChunker(token_counter=simple_token_counter)
+Ready to chunk code by line count? This gives you predictable, size-based chunks:
+
+``` py linenums="1"
+from chunklet.code_chunker import CodeChunker
+
+
+chunker = CodeChunker(max_lines=10) # (1)!
 
 chunks = chunker.chunk_text(
-    code=PYTHON_CODE,                
-    max_lines=10,               # (1)!
+    code=PYTHON_CODE,
     include_comments=True,      # (2)!
     docstring_mode="all",       # (3)!
     strict=False,               # (4)!
@@ -134,37 +133,36 @@ for i, chunk in enumerate(chunks):
 
     import os
 
-
+    class Calculator:
     Metadata:
         chunk_num: 1
         tree: global
+        └─ class Calculator
         start_line: 1
-        end_line: 7
-        span: (0, 38)
+        end_line: 8
+        span: (0, 56)
         source: N/A
 
     --- Chunk 2 ---
     Content:
-    class Calculator:
         """
         A simple calculator class.
 
         A calculator that Contains basic arithmetic operations for demonstration purposes.
         """
 
-
+        def add(self, x, y):
     Metadata:
         chunk_num: 2
         tree: global
-        └─ class Calculator
-        start_line: 8
-        end_line: 14
-        span: (38, 192)
+        └─ def add(
+        start_line: 9
+        end_line: 15
+        span: (56, 217)
         source: N/A
 
     --- Chunk 3 ---
     Content:
-        def add(self, x, y):
             """Add two numbers and return result.
 
             This is a longer description that should be truncated
@@ -173,37 +171,33 @@ for i, chunk in enumerate(chunks):
             result = x + y
             return result
 
-
+        def multiply(self, x, y):
     Metadata:
         chunk_num: 3
         tree: global
-        └─ class Calculator
-           └─ def add(
-        start_line: 15
-        end_line: 23
-        span: (192, 444)
+        ├─ def add(
+        └─ def multiply(
+        start_line: 16
+        end_line: 24
+        span: (217, 474)
         source: N/A
 
     --- Chunk 4 ---
     Content:
-        def multiply(self, x, y):
             # Multiply two numbers
             return x * y
 
     def standalone_function():
         """A standalone function."""
         return True
-
-
     Metadata:
         chunk_num: 4
         tree: global
-        ├─ class Calculator
-        │  └─ def multiply(
+        ├─ def multiply(
         └─ def standalone_function(
-        start_line: 24
+        start_line: 25
         end_line: 30
-        span: (444, 603)
+        span: (474, 603)
         source: N/A
     ```
 
@@ -213,21 +207,15 @@ for i, chunk in enumerate(chunks):
     chunker = CodeChunker(verbose=True)
     ```
 
-### Chunking by Tokens: Token Budget Master! 🪙
+### Chunking by Functions: Function Group Guru! 👥
+This constraint is useful when you want to ensure that each chunk contains a specific number of functions, helping to maintain logical code units.
 
-Here's how you can use `CodeChunker` to chunk code by the number of tokens:
-
-```py linenums="1" hl_lines="1-4 6 10"
-# Helper function
-def simple_token_counter(text: str) -> int:
-    """Simple Token Counter For Testing."""
-    return len(text.split())
-
-chunker = CodeChunker(token_counter=simple_token_counter)
+```py linenums="1" hl_lines="1"
+chunker = CodeChunker(max_functions=1) # (1)!
 
 chunks = chunker.chunk_text(
-    code=PYTHON_CODE,                
-    max_tokens=50,                        
+    code=PYTHON_CODE,
+    include_comments=False,
 )
 
 for i, chunk in enumerate(chunks):
@@ -257,18 +245,6 @@ for i, chunk in enumerate(chunks):
         A calculator that Contains basic arithmetic operations for demonstration purposes.
         """
 
-    Metadata:
-    chunk_num: 1
-    tree: global
-    └─ class Calculator
-
-    start_line: 1
-    end_line: 14
-    span: (0, 192)
-    source: N/A
-
-    --- Chunk 2 ---
-    Content:
         def add(self, x, y):
             """Add two numbers and return result.
 
@@ -278,20 +254,31 @@ for i, chunk in enumerate(chunks):
             result = x + y
             return result
 
-        def multiply(self, x, y):
-            # Multiply two numbers
-            return x * y
+    Metadata:
+    chunk_num: 1
+    tree: global
+    ├─ class Calculator
+    └─ def add(
+
+    start_line: 1
+    end_line: 23
+    span: (0, 444)
+    source: N/A
+
+    --- Chunk 2 ---
+    Content:
+    def multiply(self, x, y):
+        
+        return x * y
 
     Metadata:
     chunk_num: 2
     tree: global
-    └─ class Calculator
-       ├─ def add(
-       └─ def multiply(
+    └─ def multiply(
 
-    start_line: 15
+    start_line: 24
     end_line: 27
-    span: (192, 527)
+    span: (444, 527)
     source: N/A
 
     --- Chunk 3 ---
@@ -310,19 +297,31 @@ for i, chunk in enumerate(chunks):
     source: N/A
     ```
 
-!!! tip "Overrides token_counter"
-    You can also provide the `token_counter` directly to any chunking method (e.g., `chunker.chunk_text(..., token_counter=my_tokenizer_function)`). If a `token_counter` is provided in both the constructor and the chunking method, the one in the method call will be used.
+### Chunking by Tokens: Token Budget Master! 🪙
 
+Here's how you can use `CodeChunker` to chunk code by the number of tokens:
 
-### Chunking by Functions: Function Group Guru! 👥
-This constraint is useful when you want to ensure that each chunk contains a specific number of functions, helping to maintain logical code units.
+```py linenums="1" hl_lines="1-3 6-7"
+def simple_token_counter(text: str) -> int:
+    """Simple Token Counter For Testing."""
+    return len(text.split())
 
-```py linenums="1" hl_lines="3"
-chunks = chunker.chunk_text(
-    code=PYTHON_CODE,
-    max_functions=1,
-    include_comments=False,
+chunker = CodeChunker(
+    token_counter=simple_token_counter,
+    max_tokens=50,
 )
+
+chunks = chunker.chunk_text(
+    code=PYTHON_CODE,                
+)
+
+for i, chunk in enumerate(chunks):
+    print(f"--- Chunk {i+1} ---")
+    print(f"Content:\\n{chunk.content}")
+    print("Metadata:")
+    for k,v in chunk.metadata.items():
+        print(f"{k}: {v}")
+    print()
 ```
 
 ??? success "Click to show output"
@@ -344,6 +343,19 @@ chunks = chunker.chunk_text(
         """
 
         def add(self, x, y):
+    Metadata:
+    chunk_num: 1
+    tree: global
+    ├─ class Calculator
+    └─ def add(
+
+    start_line: 1
+    end_line: 15
+    span: (0, 217)
+    source: N/A
+
+    --- Chunk 2 ---
+    Content:
             """Add two numbers and return result.
 
             This is a longer description that should be truncated
@@ -352,61 +364,51 @@ chunks = chunker.chunk_text(
             result = x + y
             return result
 
-    Metadata:
-    chunk_num: 1
-    tree: global
-    └─ class Calculator
-       └─ def add(
-
-    start_line: 1
-    end_line: 23
-    span: (0, 444)
-    source: N/A
-
-    --- Chunk 2 ---
-    Content:
         def multiply(self, x, y):
-
+            # Multiply two numbers
             return x * y
 
+    def standalone_function():
     Metadata:
     chunk_num: 2
     tree: global
-    └─ class Calculator
-       └─ def multiply(
+    ├─ def add(
+    ├─ def multiply(
+    └─ def standalone_function(
 
-    start_line: 24
-    end_line: 27
-    span: (444, 527)
+    start_line: 16
+    end_line: 28
+    span: (217, 554)
     source: N/A
 
     --- Chunk 3 ---
     Content:
-    def standalone_function():
-        """A standalone function."""
-        return True
-
+    """A standalone function."""
+    return True
     Metadata:
     chunk_num: 3
     tree: global
     └─ def standalone_function(
 
-    start_line: 28
+    start_line: 29
     end_line: 30
-    span: (527, 603)
+    span: (554, 603)
     source: N/A
     ```
+
+!!! tip "Overrides token_counter"
+    You can also provide the `token_counter` directly to any chunking method (e.g., `chunker.chunk_text(..., token_counter=my_tokenizer_function)`). If a `token_counter` is provided in both the constructor and the chunking method, the one in the method call will be used.
 
 ### Combining Multiple Constraints: Mix and Match Magic! 🎭
 The real power of `CodeChunker` comes from combining multiple constraints. This allows for highly specific and granular control over how your code is chunked. Here are a few examples of how you can combine different constraints.
 
-```py linenums="1" hl_lines="3-5"
-chunks = chunker.chunk_text(
-    PYTHON_CODE,
-    max_lines=8,
-    max_tokens=150,
-    max_functions=1
-)
+```py linenums="1" hl_lines="1-3"
+chunker = CodeChunker()
+chunker.max_lines=8,
+chunker.max_tokens=150,
+chunker.max_functions=1
+
+chunk = chunker.chunk_text(PYTHON_CODE)
 ```
 
 ## Batch Run: Processing Multiple Code Inputs Like a Pro! 📚
@@ -517,16 +519,11 @@ func (c *Config) displayInfo() {
 
 We can process them all at once by providing a list of paths to the `chunk_files` method. Assuming these files are saved in a `code_examples` directory:
 
-```py linenums="1" hl_lines="18-25"
-from chunklet.code_chunker import CodeChunker
-
-# Helper function
-def simple_token_counter(text: str) -> int:
-    """Simple Token Counter For Testing."""
-    return len(text.split())
-
-# Initialize the chunker
-chunker = CodeChunker(token_counter=simple_token_counter)
+```py linenums="1" hl_lines="13-20"
+chunker = CodeChunker(
+    token_counter=simple_token_counter,
+    max_tokens=50,
+)
 
 sources = [
     "code_examples/cpp_calculator.cpp",
@@ -537,7 +534,6 @@ sources = [
 
 chunks = chunker.chunk_files(
     paths=sources,
-    max_tokens=50,
     include_comments=False,
     n_jobs=2,               # (1)!
     on_errors="raise",      # (2)!
@@ -583,17 +579,50 @@ for i, chunk in enumerate(chunks):
       chunk_num: 1
       tree: global
       start_line: 1
-      end_line: 17
-      span: (0, 329)
-      source: code_examples/cpp_calculator.cpp
+      end_line: 14
+      span: (0, 256)
+      source: N/A
 
-    Chunking ...:  50%|███████████████               | 2/4 [00:00, 19.73it/s]
+    Chunking ...:  50%|█████     | 2/4 [00:00, 19.26it/s]
     --- Chunk 2 ---
+    Content:
+    package com.chunker.data;
+
+    public class DataProcessor {
+        private String sourcePath;
+
+        public DataProcessor(String path) {
+            this.sourcePath = path;
+        }
+
+        public String getPath() {
+            return this.sourcePath;
+        }
+
+        public boolean process() {
+            if (this.sourcePath.isEmpty()) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    Metadata:
+      chunk_num: 1
+      tree: global
+      ├─ package com
+      └─ public class DataProcessor
+         └─ public class DataProcessor {
+      start_line: 1
+      end_line: 20
+      span: (0, 373)
+      source: N/A
+
+    --- Chunk 3 ---
     Content:
     const sanitizeInput = (input) => {
         return input.trim().substring(0, 100);
     };
-
 
     function processArray(data) {
         if (!data || data.length === 0) {
@@ -611,94 +640,48 @@ for i, chunk in enumerate(chunks):
     Metadata:
       chunk_num: 1
       tree: global
-    └─ function processArray(
+      └─ function processArray(
       start_line: 1
-      end_line: 19
-      span: (0, 372)
-      source: code_examples/js_utils.js
+      end_line: 16
+      span: (0, 291)
+      source: N/A
 
-    --- Chunk 3 ---
-    Content:
-    package com.chunker.data;
-
-    public class DataProcessor {
-        private String sourcePath;
-
-
-        public DataProcessor(String path) {
-            this.sourcePath = path;
-        }
-
-
-        public String getPath() {
-            return this.sourcePath;
-        }
-
-
-        public boolean process() {
-            if (this.sourcePath.isEmpty()) {
-                return false;
-            }
-
-            return true;
-        }
-    }
-
-    Metadata:
-      chunk_num: 1
-      tree: global
-    ├─ package com
-    └─ public class DataProcessor
-       ├─ public DataProcessor(
-       ├─ public String getPath(
-       └─ public boolean process(
-
-      start_line: 1
-      end_line: 25
-      span: (0, 500)
-      source: code_examples/JavaDataProcessor.java
-
-    Chunking ...:  50%|███████████████               | 2/4 [00:00, 19.73it/s]
     --- Chunk 4 ---
     Content:
-    package main
+    package config
 
     import (
         "fmt"
+        "os"
     )
 
-
     type Config struct {
-        Timeout int
-        Retries int
+        Host     string
+        Port     int
+        Debug    bool
     }
 
-
-    func NewConfig() Config {
-        return Config{
-            Timeout: 5000,
-            Retries: 3,
+    func (c *Config) Load() error {
+        if c.Host == "" {
+            return fmt.Errorf("host is required")
         }
+        return nil
     }
 
-
-    func (c *Config) displayInfo() {
-        fmt.Printf("Timeout: %dms, Retries: %d\n", c.Timeout, c.Retries)
-    }
+    func (c *Config) DisplayInfo() {
+        fmt.Printf("Host: %s, Port: %d, Debug: %t
 
     Metadata:
       chunk_num: 1
       tree: global
-    ├─ package main
-    ├─ type Config
-    └─ func NewConfig(
-
+      ├─ package config
+      └─ type Config
       start_line: 1
-      end_line: 26
-      span: (0, 382)
-      source: code_examples/go_config.go
+      end_line: 23
+      span: (0, 331)
+      source: N/A
 
-    Chunking ...: 100%|██████████████████████████████| 4/4 [00:00, 19.71it/s]
+    Chunking ...: 100%|██████████| 4/4 [00:00, 12.45it/s]
     ```
 
 !!! warning "Generator Cleanup"
@@ -712,14 +695,8 @@ The `separator` parameter lets you add a custom marker that gets yielded after a
 !!! note "note"
     `None` cannot be used as a separator.
 
-```py linenums="1" hl_lines="2 32 37 40-43"
-from chunklet.code_chunker import CodeChunker
+```py linenums="1" hl_lines="1 31 35 38-41"
 from more_itertools import split_at
-
-# Helper function
-def simple_token_counter(text: str) -> int:
-    """Simple Token Counter For Testing."""
-    return len(text.split())
 
 SIMPLE_SOURCES = [
     # Python: Simple Function Definition Boundary
@@ -744,12 +721,15 @@ public class Utility
     '''
 ]
 
-chunker = CodeChunker(token_counter=simple_token_counter)
+chunker = CodeChunker(
+    token_counter=simple_token_counter,
+    max_tokens=20,
+)
+
 custom_separator = "---END_OF_SOURCE---"
 
 chunks_with_separators = chunker.chunk_texts(
     codes=SIMPLE_SOURCES,
-    max_tokens=20,
     separator=custom_separator,
 )
 

--- a/docs/getting-started/programmatic/code_chunker.md
+++ b/docs/getting-started/programmatic/code_chunker.md
@@ -99,20 +99,20 @@ Ready to chunk code by line count? This gives you predictable, size-based chunks
 from chunklet.code_chunker import CodeChunker
 
 
-chunker = CodeChunker(max_lines=10) # (1)!
+chunker = CodeChunker(max_lines=10)  # (1)!
 
 chunks = chunker.chunk_text(
     code=PYTHON_CODE,
-    include_comments=True,      # (2)!
-    docstring_mode="all",       # (3)!
-    strict=False,               # (4)!
+    include_comments=True,  # (2)!
+    docstring_mode="all",  # (3)!
+    strict=False,  # (4)!
 )
 
 for i, chunk in enumerate(chunks):
-    print(f"--- Chunk {i+1} ---")
+    print(f"--- Chunk {i + 1} ---")
     print(f"Content:\\n{chunk.content}")
     print("Metadata:")
-    for k,v in chunk.metadata.items():
+    for k, v in chunk.metadata.items():
         print(f"{k}: {v}")
     print()
 ```
@@ -211,7 +211,7 @@ for i, chunk in enumerate(chunks):
 This constraint is useful when you want to ensure that each chunk contains a specific number of functions, helping to maintain logical code units.
 
 ```py linenums="1" hl_lines="1"
-chunker = CodeChunker(max_functions=1) # (1)!
+chunker = CodeChunker(max_functions=1)
 
 chunks = chunker.chunk_text(
     code=PYTHON_CODE,
@@ -219,10 +219,10 @@ chunks = chunker.chunk_text(
 )
 
 for i, chunk in enumerate(chunks):
-    print(f"--- Chunk {i+1} ---")
+    print(f"--- Chunk {i + 1} ---")
     print(f"Content:\\n{chunk.content}")
     print("Metadata:")
-    for k,v in chunk.metadata.items():
+    for k, v in chunk.metadata.items():
         print(f"{k}: {v}")
     print()
 ```
@@ -301,10 +301,11 @@ for i, chunk in enumerate(chunks):
 
 Here's how you can use `CodeChunker` to chunk code by the number of tokens:
 
-```py linenums="1" hl_lines="1-3 6-7"
+```py linenums="1" hl_lines="1-3 7"
 def simple_token_counter(text: str) -> int:
     """Simple Token Counter For Testing."""
     return len(text.split())
+
 
 chunker = CodeChunker(
     token_counter=simple_token_counter,
@@ -312,14 +313,14 @@ chunker = CodeChunker(
 )
 
 chunks = chunker.chunk_text(
-    code=PYTHON_CODE,                
+    code=PYTHON_CODE,
 )
 
 for i, chunk in enumerate(chunks):
-    print(f"--- Chunk {i+1} ---")
+    print(f"--- Chunk {i + 1} ---")
     print(f"Content:\\n{chunk.content}")
     print("Metadata:")
-    for k,v in chunk.metadata.items():
+    for k, v in chunk.metadata.items():
         print(f"{k}: {v}")
     print()
 ```
@@ -403,10 +404,9 @@ for i, chunk in enumerate(chunks):
 The real power of `CodeChunker` comes from combining multiple constraints. This allows for highly specific and granular control over how your code is chunked. Here are a few examples of how you can combine different constraints.
 
 ```py linenums="1" hl_lines="1-3"
-chunker = CodeChunker()
-chunker.max_lines=8,
-chunker.max_tokens=150,
-chunker.max_functions=1
+chunker.max_lines = 8
+chunker.max_tokens = 150
+chunker.max_functions = 1
 
 chunk = chunker.chunk_text(PYTHON_CODE)
 ```
@@ -419,7 +419,9 @@ While `chunk_text`/`chunk_file` is perfect for single code inputs, `chunk_texts`
 - `chunk_files()` - process multiple file paths
 
 Given we have the following code snippets saved as individual files in a `code_examples` directory:
-# cpp_calculator.cpp
+<details>
+<summary>cpp_calculator.cpp</summary>
+
 ```cpp
 #include <iostream>
 #include <string>
@@ -439,7 +441,11 @@ int calculate_sum(int a, int b) {
 }
 ```
 
-# JavaDataProcessor.java
+</details>
+
+<details>
+<summary>JavaDataProcessor.java</summary>
+
 ```java
 package com.chunker.data;
 
@@ -467,7 +473,11 @@ public class DataProcessor {
 }
 ```
 
-# js_utils.js
+</details>
+
+<details>
+<summary>js_utils.js</summary>
+
 ```javascript
 // Utility function
 const sanitizeInput = (input) => {
@@ -489,7 +499,11 @@ function processArray(data) {
 }
 ```
 
-# go_config.go
+</details>
+
+<details>
+<summary>go_config.go</summary>
+
 ```go
 package main
 
@@ -517,9 +531,11 @@ func (c *Config) displayInfo() {
 }
 ```
 
+</details>
+
 We can process them all at once by providing a list of paths to the `chunk_files` method. Assuming these files are saved in a `code_examples` directory:
 
-```py linenums="1" hl_lines="13-20"
+```py linenums="1" hl_lines="13-19"
 chunker = CodeChunker(
     token_counter=simple_token_counter,
     max_tokens=50,
@@ -535,17 +551,17 @@ sources = [
 chunks = chunker.chunk_files(
     paths=sources,
     include_comments=False,
-    n_jobs=2,               # (1)!
-    on_errors="raise",      # (2)!
-    show_progress=True,     # (3)!
+    n_jobs=2,  # (1)!
+    on_errors="raise",  # (2)!
+    show_progress=True,  # (3)!
 )
 
 # Output the results
 for i, chunk in enumerate(chunks):
-    print(f"--- Chunk {i+1} ---")
+    print(f"--- Chunk {i + 1} ---")
     print(f"Content:\n{chunk.content.strip()}\n")
     print("Metadata:")
-    for k,v in chunk.metadata.items():
+    for k, v in chunk.metadata.items():
         print(f"  {k}: {v}")
     print()
 ```
@@ -700,7 +716,7 @@ The `separator` parameter lets you add a custom marker that gets yielded after a
 !!! note "note"
     `None` cannot be used as a separator.
 
-```py linenums="1" hl_lines="1 31 35 38-41"
+```py linenums="1" hl_lines="1 30 34 37-41"
 from more_itertools import split_at
 
 SIMPLE_SOURCES = [
@@ -711,9 +727,8 @@ def greet_user(name):
     message = "Welcome back, " + name
     return message
     ''',
-
     # C#: Simple Method and Class Boundary
-    '''
+    """
 public class Utility
 {
     // C# Method
@@ -723,7 +738,7 @@ public class Utility
         return sum;
     }
 }
-    '''
+    """,
 ]
 
 chunker = CodeChunker(
@@ -741,8 +756,8 @@ chunks_with_separators = chunker.chunk_texts(
 chunk_groups = split_at(chunks_with_separators, lambda x: x == custom_separator)
 # Process the results using split_at
 for i, code_chunks in enumerate(chunk_groups):
-    if code_chunks: # (1)!
-        print(f"--- Chunks for Document {i+1} ---")
+    if code_chunks:  # (1)!
+        print(f"--- Chunks for Document {i + 1} ---")
         for chunk in code_chunks:
             print(f"Content:\n {chunk.content}\n")
             print(f"Metadata: {chunk.metadata}")
@@ -761,27 +776,27 @@ for i, code_chunks in enumerate(chunk_groups):
         message = "Welcome back, " + name
         return message
 
-    Metadata: {'chunk_num': 1, 'tree': 'global\n└─ def greet_user(\n', 'start_line': 1, 'end_line': 5, 'span': (0, 124), 'source': 'N/A'}
+    Metadata: {'chunk_num': 1, 'tree': 'global\n└─ def greet_user(\n', 'start_line': 1, 'end_line': 6, 'span': (0, 128), 'source': 'N/A'}
 
-    Chunking ...:  50%|███████████████               | 1/2 [00:00,  9.48it/s]
+    Chunking ...:  50%|█████     | 1/2 [00:00,  9.70it/s]
     --- Chunks for Document 2 ---
     Content:
     public class Utility
     {
-        // C# Method
 
-    Metadata: {'chunk_num': 1, 'tree': 'global\n└─ public class Utility\n', 'start_line': 1, 'end_line': 4, 'span': (0, 41), 'source': 'N/A'}
+    Metadata: {'chunk_num': 1, 'tree': 'global\n└─ public class Utility\n', 'start_line': 1, 'end_line': 3, 'span': (0, 24), 'source': 'N/A'}
     Content:
-         public int Add(int x, int y)
-        {
-            int sum = x + y;
-            return sum;
-        }
+     // C# Method
+    public int Add(int x, int y)
+    {
+        int sum = x + y;
+        return sum;
+    }
     }
 
-    Metadata: {'chunk_num': 2, 'tree': 'global\n└─ public class Utility\n   └─ public int Add(\n', 'start_line': 5, 'end_line': 10, 'span': (41, 133), 'source': 'N/A'}
+    Metadata: {'chunk_num': 2, 'tree': 'global\n└─ public class Utility\n   └─ public int Add(\n', 'start_line': 4, 'end_line': 11, 'span': (24, 137), 'source': 'N/A'}
 
-    Chunking ...: 100%|██████████████████████████████| 2/2 [00:00,  1.92it/s]
+    Chunking ...: 100%|██████████| 2/2 [00:01,  1.01it/s]
     ```
 
 !!! question "What are the limitations of CodeChunker?"

--- a/docs/getting-started/programmatic/document_chunker.md
+++ b/docs/getting-started/programmatic/document_chunker.md
@@ -100,16 +100,16 @@ from chunklet.document_chunker import DocumentChunker
 text = "..."  # The text from above
 
 chunker = DocumentChunker(  # (1)!
-    lang="auto",             # (2)!
+    lang="auto",  # (2)!
     max_sentences=2,
-    overlap_percent=0,       # (3)!
-    offset=0,                # (4)!
+    overlap_percent=0,  # (3)!
+    offset=0,  # (4)!
 )
 
 chunks = chunker.chunk_text(text=text)
 
 for i, chunk in enumerate(chunks):
-    print(f"--- Chunk {i+1} ---")
+    print(f"--- Chunk {i + 1} ---")
     print(f"Metadata: {chunk.metadata}")
     print(f"Content: {chunk.content}")
     print()
@@ -163,13 +163,13 @@ for i, chunk in enumerate(chunks):
 
 This constraint is useful for documents structured with Markdown headings or thematic breaks.
 
-``` py linenums="1" hl_lines="2"
+``` py linenums="1" hl_lines="1"
 chunker = DocumentChunker(max_section_breaks=2)
 
 chunks = chunker.chunk_text(text=text)
 
 for i, chunk in enumerate(chunks):
-    print(f"--- Chunk {i+1} ---")
+    print(f"--- Chunk {i + 1} ---")
     print(f"Metadata: {chunk.metadata}")
     print(f"Content: {chunk.content}")
     print()
@@ -214,18 +214,20 @@ for i, chunk in enumerate(chunks):
 !!! note "Token Counter Requirement"
     When using the `max_tokens` constraint, a `token_counter` function is essential. This function, which you provide, should accept a string and return an integer representing its token count. Failing to provide a `token_counter` will result in a [`MissingTokenCounterError`](../../exceptions-and-warnings.md#missingtokencountererror).
 
-```py linenums="1" hl_lines="3-4 6"
+```py linenums="1" hl_lines="4-5 8"
 from chunklet.document_chunker import DocumentChunker
+
 
 def word_counter(text: str) -> int:
     return len(text.split())
+
 
 chunker = DocumentChunker(token_counter=word_counter, max_tokens=50)
 
 chunks = chunker.chunk_text(text=text)
 
 for i, chunk in enumerate(chunks):
-    print(f"--- Chunk {i+1} ---")
+    print(f"--- Chunk {i + 1} ---")
     print(f"Metadata: {chunk.metadata}")
     print(f"Content: {chunk.content}")
     print()
@@ -336,12 +338,11 @@ While `chunk_text` is perfect for single texts and `chunk_file` for single files
 
 ### For Texts
 
-```py linenums="1" hl_lines="14-19"
-def word_counter(text: str) -> int:
-    return len(text.split())
-
+```py linenums="1" hl_lines="13-18"
 EN_TEXT = "This is the first document. It has multiple sentences for chunking. Here is the second document."
-ES_TEXT = "Este es el primer documento. Contiene varias frases para la segmentación de texto."
+ES_TEXT = (
+    "Este es el primer documento. Contiene varias frases para la segmentación de texto."
+)
 
 chunker = DocumentChunker(
     token_counter=word_counter,
@@ -352,13 +353,13 @@ chunker = DocumentChunker(
 
 chunks = chunker.chunk_texts(
     texts=[EN_TEXT, ES_TEXT],
-    n_jobs=2,                    # (1)!
-    on_errors="raise",           # (2)!
-    show_progress=True,          # (3)!
+    n_jobs=2,  # (1)!
+    on_errors="raise",  # (2)!
+    show_progress=True,  # (3)!
 )
 
 for i, chunk in enumerate(chunks):
-    print(f"--- Chunk {i+1} ---")
+    print(f"--- Chunk {i + 1} ---")
     print(f"Metadata: {chunk.metadata}")
     print(f"Content: {chunk.content}")
     print()
@@ -414,7 +415,7 @@ from more_itertools import split_at
 chunker = DocumentChunker(max_sentences=1)
 texts = [
     "This is the first document. It has two sentences.",
-    "This is the second document. It also has two sentences."
+    "This is the second document. It also has two sentences.",
 ]
 custom_separator = "---END_OF_DOCUMENT---"
 
@@ -427,8 +428,8 @@ chunks_with_separators = chunker.chunk_texts(
 chunk_groups = split_at(chunks_with_separators, lambda x: x == custom_separator)
 # Process the results using split_at
 for i, doc_chunks in enumerate(chunk_groups):
-    if doc_chunks:        # (1)!
-        print(f"--- Chunks for Document {i+1} ---")
+    if doc_chunks:  # (1)!
+        print(f"--- Chunks for Document {i + 1} ---")
         for chunk in doc_chunks:
             print(f"Content: {chunk.content}")
             print(f"Metadata: {chunk.metadata}")
@@ -469,7 +470,7 @@ To use a custom processor, you leverage the [`@registry.register`](../../referen
     - For multi-section documents, return a list of strings - each will be processed as a separate section
     - If an error occurs during the document processing (e.g., an issue with the custom processor function), a [`CallbackError`](../../exceptions-and-warnings.md#callbackerror) will be raised
 
-```py linenums="1" hl_lines="5-7 9-19 21 44-48 50-51"
+```py linenums="1" hl_lines="5-7 10-20 23 43-47 49-50"
 import os
 import re
 import json
@@ -478,10 +479,11 @@ from chunklet.document_chunker import CustomProcessorRegistry, DocumentChunker
 
 registry = CustomProcessorRegistry()
 
+
 # Define a simple custom processor for .json files
 @registry.register(".json", name="MyJSONProcessor")
 def my_json_processor(file_path: str) -> tuple[str, dict]:
-    with open(file_path, 'r') as f:
+    with open(file_path, "r") as f:
         data = json.load(f)
 
     # Assuming the json has a "text" field with paragraphs
@@ -490,23 +492,21 @@ def my_json_processor(file_path: str) -> tuple[str, dict]:
     metadata["source"] = file_path
     return text_content, metadata
 
+
 chunker = DocumentChunker(processor_registry=registry, max_sentences=5)
 
 # A complex JSON sample
 json_data = {
-    "metadata": {
-        "document_id": "doc-12345",
-        "created_at": "2025-11-05"
-    },
+    "metadata": {"document_id": "doc-12345", "created_at": "2025-11-05"},
     "text": [
         "This is the first paragraph of our longer JSON sample. It contains multiple sentences to test the chunking process.",
         "The second paragraph introduces a new topic. We are exploring the capabilities of custom processors in the chunklet library.",
-        "Finally, the third paragraph concludes our sample. We hope this demonstrates the flexibility of the system in handling various data formats."
-    ]
+        "Finally, the third paragraph concludes our sample. We hope this demonstrates the flexibility of the system in handling various data formats.",
+    ],
 }
 
 # Use a temporary file
-with tempfile.NamedTemporaryFile(mode='w+', suffix=".json") as tmp:
+with tempfile.NamedTemporaryFile(mode="w+", suffix=".json") as tmp:
     json.dump(json_data, tmp)
     tmp.seek(0)
     tmp_path = tmp.name
@@ -514,7 +514,7 @@ with tempfile.NamedTemporaryFile(mode='w+', suffix=".json") as tmp:
     chunks = chunker.chunk_file(path=tmp_path)
 
     for i, chunk in enumerate(chunks):
-        print(f"--- Chunk {i+1} ---")
+        print(f"--- Chunk {i + 1} ---")
         print(f"Content:\n{chunk.content}\n")
         print(f"Metadata:\n{chunk.metadata}")
         print()

--- a/docs/getting-started/programmatic/document_chunker.md
+++ b/docs/getting-started/programmatic/document_chunker.md
@@ -396,6 +396,11 @@ chunks = chunker.chunk_files(PATHS, ...)
 !!! warning "Generator Cleanup"
     When using `chunk_texts`, it's crucial to ensure the generator is properly closed, especially if you don't iterate through all the chunks. This is necessary to release the underlying multiprocessing resources. The recommended way is to use a `try...finally` block to call `close()` on the generator. For more details, see the [Troubleshooting](../../troubleshooting.md) guide.
 
+!!! note "Non-Deterministic Batch Ordering"
+    When using `chunk_texts` or `chunk_files` with parallel processing (`n_jobs > 1`), chunks from different inputs are processed concurrently by multiple worker processes. The order in which chunks are yielded depends on which worker finishes first, which varies with system load and scheduling. So the overall ordering of chunks across inputs is not guaranteed to be stable between runs. The `chunk_num` field within each chunk's metadata still reflects the chunk's position within its source input.
+
+    When using the `separator` parameter, the separator-based grouping is deterministic even with parallel processing.
+
 ### Separator: Keeping Your Batches Organized! 📋
 
 The `separator` parameter works for both `chunk_texts` and `chunk_files`. It lets you add a custom marker that gets yielded after all chunks from a single input are processed. Super handy for batch processing when you want to clearly separate chunks from different source texts.

--- a/docs/getting-started/programmatic/document_chunker.md
+++ b/docs/getting-started/programmatic/document_chunker.md
@@ -52,9 +52,12 @@ The `DocumentChunker` comes packed with smart features that make it your go-to t
 | `max_sentences`      | `int >= 1`        | Sentence power mode! Tell us how many sentences per chunk, and we'll group them thoughtfully so your ideas flow like a well-written story. |
 | `max_tokens`         | `int >= 12`       | Token budget watcher! We'll carefully pack sentences into chunks while respecting your token limits. If a sentence gets too chatty, we'll politely split it at clause boundaries. 🤐 |
 | `max_section_breaks` | `int >= 1`        | Structure superhero! Limits section breaks per chunk — headings (`##`), horizontal rules (`---`, `***`, `___`), and `<details>` tags. Your document structure stays intact! |
+| `overlap_percent`    | `int 0-75`        | Repeat a bit of the previous chunk's tail for continuity. Defaults to 20. |
+| `offset`             | `int >= 0`        | Skip the first N sentences before chunking. Defaults to 0. |
+| `lang`               | `str`             | Language code (`'en'`, `'fr'`, ...) or `'auto'`. Defaults to `'auto'`. |
 
 !!! note "Quick Note: Constraints Required!"
-    You must specify at least one limit (`max_sentences`, `max_tokens`, or `max_section_breaks`) when using chunking methods. Forget to add one? You'll get an [`InvalidInputError`](../../exceptions-and-warnings.md#invalidinputerror)!
+    You must specify at least one limit (`max_sentences`, `max_tokens`, or `max_section_breaks`) when constructing. Forget to add one? You'll get an [`InvalidInputError`](../../exceptions-and-warnings.md#invalidinputerror)!
 
 The `DocumentChunker` has four main methods: `chunk_text`, `chunk_file`, `chunk_texts`, and `chunk_files`. `chunk_text` and `chunk_file` return a list of [`DotDict`][chunklet.common.dotdict.DotDict] objects, while `chunk_texts` and `chunk_files` are memory-friendly generators that yield chunks one by one. Each `DotDict` has `content` (the actual text) and `metadata` (all the juicy details). Check the [Metadata guide](../metadata.md#documentchunker-metadata) for the full scoop!
 
@@ -84,16 +87,6 @@ There are several strategies for chunking, including splitting by sentences, by 
 
 ---
 
-## Advanced Chunking Techniques
-
-Ready to go beyond the basics? Let's explore some pro-level techniques!
-
-### Overlap Considerations
-
-Overlap is your secret weapon! It includes a bit of the previous chunk at the start of the next one, ensuring your text doesn't feel choppy or disconnected.
-
----
-
 # Conclusion
 
 In conclusion, mastering chunking is key to unlocking the full potential of your text data.
@@ -106,15 +99,14 @@ from chunklet.document_chunker import DocumentChunker
 
 text = "..."  # The text from above
 
-chunker = DocumentChunker()  # (1)!
-
-chunks = chunker.chunk_text(
-    text=text,
+chunker = DocumentChunker(  # (1)!
     lang="auto",             # (2)!
     max_sentences=2,
     overlap_percent=0,       # (3)!
-    offset=0                 # (4)!
+    offset=0,                # (4)!
 )
+
+chunks = chunker.chunk_text(text=text)
 
 for i, chunk in enumerate(chunks):
     print(f"--- Chunk {i+1} ---")
@@ -131,156 +123,50 @@ for i, chunk in enumerate(chunks):
 ??? success "Click to show output"
     ```linenums="0"
     --- Chunk 1 ---
-    Metadata: {'chunk_num': 1, 'span': (1, 73)}
+    Metadata: {'chunk_num': 1, 'span': (0, 60)}
     Content: # Introduction to Chunking
     This is the first paragraph of our document.
 
     --- Chunk 2 ---
-    Metadata: {'chunk_num': 2, 'span': (74, 259)}
+    Metadata: {'chunk_num': 2, 'span': (73, 227)}
     Content: It discusses the importance of text segmentation for various NLP tasks, such as RAG systems and summarization.
     We aim to break down large documents into manageable, context-rich pieces.
 
-    ## Why is Chunking Important?
+    --- Chunk 3 ---
+    Metadata: {'chunk_num': 3, 'span': (260, 353)}
+    Content: ## Why is Chunking Important?
     Effective chunking helps in maintaining the semantic coherence of information.
 
-    --- Chunk 3 ---
-    Metadata: {'chunk_num': 3, 'span': (261, 370)}
+    --- Chunk 4 ---
+    Metadata: {'chunk_num': 4, 'span': (370, 528)}
     Content: It ensures that each piece of text retains enough context to be meaningful on its own, which is crucial for downstream applications.
 
     ### Different Strategies
 
-    --- Chunk 4 ---
-    Metadata: {'chunk_num': 4, 'span': (371, 529)}
+    --- Chunk 5 ---
+    Metadata: {'chunk_num': 5, 'span': (530, 710)}
     Content: There are several strategies for chunking, including splitting by sentences, by a fixed number of tokens, or by structural elements like headings.
     Each method has its own advantages depending on the specific use case.
 
-    --- Chunk 5 ---
-    Metadata: {'chunk_num': 5, 'span': (531, 748)}
+    --- Chunk 6 ---
+    Metadata: {'chunk_num': 6, 'span': (749, 766)}
     Content: ---
 
-    ## Advanced Chunking Techniques
-
-    --- Chunk 6 ---
-    Metadata: {'chunk_num': 6, 'span': (750, 787)}
-    Content: Ready to go beyond the basics?
-    Let's explore some pro-level techniques!
+    # Conclusion
 
     --- Chunk 7 ---
-    Metadata: {'chunk_num': 7, 'span': (788, 859)}
-    Content: ### Overlap Considerations
-    Overlap is your secret weapon!
-
-    --- Chunk 8 ---
-    Metadata: {'chunk_num': 8, 'span': (861, 919)}
-    Content: ### Overlap Considerations
-    Overlap is your secret weapon!
-
-    --- Chunk 9 ---
-    Metadata: {'chunk_num': 9, 'span': (920, 1050)}
-    Content: It includes a bit of the previous chunk at the start of the next one, ensuring your text doesn't feel choppy or disconnected.
-
-    ---
-
-    --- Chunk 10 ---
-    Metadata: {'chunk_num': 10, 'span': (1052, 1157)}
-    Content: # Conclusion
-    In conclusion, mastering chunking is key to unlocking the full potential of your text data.
+    Metadata: {'chunk_num': 7, 'span': (768, 859)}
+    Content: In conclusion, mastering chunking is key to unlocking the full potential of your text data.
     ```
-
-### Chunking by Tokens: Token Budget Master! 🪙
-
-!!! note "Token Counter Requirement"
-    When using the `max_tokens` constraint, a `token_counter` function is essential. This function, which you provide, should accept a string and return an integer representing its token count. Failing to provide a `token_counter` will result in a [`MissingTokenCounterError`](../../exceptions-and-warnings.md#missingtokencountererror).
-
-```py linenums="1" hl_lines="1 3-4 6 10"
-from chunklet.document_chunker import DocumentChunker
-
-def word_counter(text: str) -> int:
-    return len(text.split())
-
-chunker = DocumentChunker(token_counter=word_counter)
-
-chunks = chunker.chunk_text(
-    text=text,
-    max_tokens=50,
-)
-
-for i, chunk in enumerate(chunks):
-    print(f"--- Chunk {i+1} ---")
-    print(f"Metadata: {chunk.metadata}")
-    print(f"Content: {chunk.content}")
-    print()
-```
-
-??? success "Click to show output"
-    ```linenums="0"
-    --- Chunk 1 ---
-    Metadata: {'chunk_num': 1, 'span': (1, 290)}
-    Content: # Introduction to Chunking
-    This is the first paragraph of our document.
-    It discusses the importance of text segmentation for various NLP tasks, such as RAG systems and summarization.
-    We aim to break down large documents into manageable, context-rich pieces.
-
-    ## Why is Chunking Important?
-
-    --- Chunk 2 ---
-    Metadata: {'chunk_num': 2, 'span': (261, 573)}
-    Content: ... 
-    ## Why is Chunking Important?
-
-    Effective chunking helps in maintaining the semantic coherence of information.
-    It ensures that each piece of text retains enough context to be meaningful on its own, which is crucial for downstream applications.
-
-    ### Different Strategies
-    There are several strategies for chunking,
-
-    --- Chunk 3 ---
-    Metadata: {'chunk_num': 3, 'span': (531, 859)}
-    Content: There are several strategies for chunking,
-    including splitting by sentences, by a fixed number of tokens, or by structural elements like headings.
-    Each method has its own advantages depending on the specific use case.
-
-    ---
-
-    ## Advanced Chunking Techniques
-    Ready to go beyond the basics?
-    Let's explore some pro-level techniques!
-
-    --- Chunk 4 ---
-    Metadata: {'chunk_num': 4, 'span': (819, 1080)}
-    Content: Let's explore some pro-level techniques!
-
-
-
-    ### Overlap Considerations
-    Overlap is your secret weapon!
-    It includes a bit of the previous chunk at the start of the next one, ensuring your text doesn't feel choppy or disconnected.
-
-    ---
-
-    # Conclusion
-    In conclusion,
-
-    --- Chunk 5 ---
-    Metadata: {'chunk_num': 5, 'span': (1052, 1157)}
-    Content: ... 
-    # Conclusion
-    In conclusion,
-    mastering chunking is key to unlocking the full potential of your text data.
-    ```
-
-!!! tip "Overrides token_counter"
-    You can also provide the `token_counter` directly to any chunking method. If provided in both the constructor and the method, the one in the method will be used.
 
 ### Chunking by Section Breaks: Structure Superhero! 🦸‍♀️
 
 This constraint is useful for documents structured with Markdown headings or thematic breaks.
 
-``` py linenums="1" hl_lines="3"
-chunks = chunker.chunk_text(
-    text=text,
-    max_section_breaks=2
-)
+``` py linenums="1" hl_lines="2"
+chunker = DocumentChunker(max_section_breaks=2)
+
+chunks = chunker.chunk_text(text=text)
 
 for i, chunk in enumerate(chunks):
     print(f"--- Chunk {i+1} ---")
@@ -292,7 +178,7 @@ for i, chunk in enumerate(chunks):
 ??? success "Click to show output"
     ```linenums="0"
     --- Chunk 1 ---
-    Metadata: {'chunk_num': 1, 'span': (1, 503)}
+    Metadata: {'chunk_num': 1, 'span': (0, 414)}
     Content: # Introduction to Chunking
     This is the first paragraph of our document.
     It discusses the importance of text segmentation for various NLP tasks, such as RAG systems and summarization.
@@ -303,7 +189,7 @@ for i, chunk in enumerate(chunks):
     It ensures that each piece of text retains enough context to be meaningful on its own, which is crucial for downstream applications.
 
     --- Chunk 2 ---
-    Metadata: {'chunk_num': 2, 'span': (371, 753)}
+    Metadata: {'chunk_num': 2, 'span': (370, 681)}
     Content: It ensures that each piece of text retains enough context to be meaningful on its own,
     which is crucial for downstream applications.
 
@@ -314,28 +200,8 @@ for i, chunk in enumerate(chunks):
     ---
 
     --- Chunk 3 ---
-    Metadata: {'chunk_num': 3, 'span': (678, 859)}
+    Metadata: {'chunk_num': 3, 'span': (677, 822)}
     Content: Each method has its own advantages depending on the specific use case.
-
-    ---
-
-    ## Advanced Chunking Techniques
-    Ready to go beyond the basics?
-    Let's explore some pro-level techniques!
-
-    --- Chunk 4 ---
-    Metadata: {'chunk_num': 4, 'span': (819, 1050)}
-    Content: Let's explore some pro-level techniques!
-
-    ### Overlap Considerations
-    Overlap is your secret weapon!
-    It includes a bit of the previous chunk at the start of the next one, ensuring your text doesn't feel choppy or disconnected.
-
-    ---
-
-    --- Chunk 5 ---
-    Metadata: {'chunk_num': 5, 'span': (1047, 1157)}
-    Content: ... 
 
     ---
 
@@ -343,17 +209,82 @@ for i, chunk in enumerate(chunks):
     In conclusion, mastering chunking is key to unlocking the full potential of your text data.
     ```
 
+### Chunking by Tokens: Token Budget Master! 🪙
+
+!!! note "Token Counter Requirement"
+    When using the `max_tokens` constraint, a `token_counter` function is essential. This function, which you provide, should accept a string and return an integer representing its token count. Failing to provide a `token_counter` will result in a [`MissingTokenCounterError`](../../exceptions-and-warnings.md#missingtokencountererror).
+
+```py linenums="1" hl_lines="3-4 6"
+from chunklet.document_chunker import DocumentChunker
+
+def word_counter(text: str) -> int:
+    return len(text.split())
+
+chunker = DocumentChunker(token_counter=word_counter, max_tokens=50)
+
+chunks = chunker.chunk_text(text=text)
+
+for i, chunk in enumerate(chunks):
+    print(f"--- Chunk {i+1} ---")
+    print(f"Metadata: {chunk.metadata}")
+    print(f"Content: {chunk.content}")
+    print()
+```
+
+??? success "Click to show output"
+    ```linenums="0"
+    --- Chunk 1 ---
+    Metadata: {'chunk_num': 1, 'span': (0, 237)}
+    Content: # Introduction to Chunking
+    This is the first paragraph of our document.
+    It discusses the importance of text segmentation for various NLP tasks, such as RAG systems and summarization.
+    We aim to break down large documents into manageable, context-rich pieces.
+
+    ## Why is Chunking Important?
+
+    --- Chunk 2 ---
+    Metadata: {'chunk_num': 2, 'span': (260, 520)}
+    Content: ... 
+    ## Why is Chunking Important?
+
+    Effective chunking helps in maintaining the semantic coherence of information.
+    It ensures that each piece of text retains enough context to be meaningful on its own, which is crucial for downstream applications.
+
+    ### Different Strategies
+    There are several strategies for chunking,
+
+    --- Chunk 3 ---
+    Metadata: {'chunk_num': 3, 'span': (530, 733)}
+    Content: There are several strategies for chunking,
+    including splitting by sentences, by a fixed number of tokens, or by structural elements like headings.
+    Each method has its own advantages depending on the specific use case.
+
+    ---
+
+    # Conclusion
+    In conclusion,
+
+    --- Chunk 4 ---
+    Metadata: {'chunk_num': 4, 'span': (754, 841)}
+    Content: ... 
+    # Conclusion
+    In conclusion,
+    mastering chunking is key to unlocking the full potential of your text data.
+    ```
+
+!!! tip "Overrides token_counter"
+    You can also provide the `token_counter` directly to any chunking method. If provided in both the constructor and the method, the one in the method will be used.
+
 ### Combining Multiple Constraints: Mix and Match Magic! 🎭
 
 The real power of `DocumentChunker` comes from combining multiple constraints. The chunking will stop as soon as any of the limits is reached.
 
-``` py linenums="1" hl_lines="3-5"
-chunks = chunker.chunk_text(
-    text,
-    max_sentences=5,
-    max_tokens=100,
-    max_section_breaks=2
-)
+``` py linenums="1" hl_lines="1-3"
+chunker.max_sentences = 5
+chunker.max_tokens = 100
+chunker.max_section_breaks = 2
+
+chunks = chunker.chunk_text(text)
 ```
 
 !!! tip "Customizing the Continuation Marker"
@@ -381,28 +312,11 @@ chunks = chunker.chunk_text(
 
 ## Single File: Process One Document! 📄
 
-While `chunk_text` is perfect for plain text, `chunk_file` handles document files. It supports the same constraints (max_sentences, max_tokens, max_section_breaks, etc.).
+While `chunk_text` is perfect for plain text, `chunk_file` handles document files. It uses the same constraints (max_sentences, max_tokens, max_section_breaks, etc.) configured on the constructor.
 
 ``` py linenums="1"
-from chunklet.document_chunker import DocumentChunker
-
 file_path = "sample_text.txt"
-
-chunker = DocumentChunker()
-
-chunks = chunker.chunk_file(
-    path=file_path,
-    lang="auto",
-    max_sentences=4,
-    overlap_percent=20,
-    offset=0
-)
-
-for i, chunk in enumerate(chunks):
-    print(f"--- Chunk {i+1} ---")
-    print(f"Metadata: {chunk.metadata}")
-    print(f"Content: {chunk.content}")
-    print()
+chunks = chunker.chunk_file(path=file_path)
 ```
 
 !!! note "Special Handling for Streaming Processors"
@@ -422,22 +336,22 @@ While `chunk_text` is perfect for single texts and `chunk_file` for single files
 
 ### For Texts
 
-```py linenums="1" hl_lines="11-19"
-from chunklet.document_chunker import DocumentChunker
-
+```py linenums="1" hl_lines="14-19"
 def word_counter(text: str) -> int:
     return len(text.split())
 
 EN_TEXT = "This is the first document. It has multiple sentences for chunking. Here is the second document."
 ES_TEXT = "Este es el primer documento. Contiene varias frases para la segmentación de texto."
 
-chunker = DocumentChunker(token_counter=word_counter)
-
-chunks = chunker.chunk_texts(
-    texts=[EN_TEXT, ES_TEXT],
+chunker = DocumentChunker(
+    token_counter=word_counter,
     max_sentences=5,
     max_tokens=20,
     overlap_percent=30,
+)
+
+chunks = chunker.chunk_texts(
+    texts=[EN_TEXT, ES_TEXT],
     n_jobs=2,                    # (1)!
     on_errors="raise",           # (2)!
     show_progress=True,          # (3)!
@@ -457,34 +371,15 @@ for i, chunk in enumerate(chunks):
 ??? success "Click to show output"
     ```linenums="0"
     --- Chunk 1 ---
-    Metadata: {'chunk_num': 1, 'span': (0, 82)}
-    Content: Este es el primer documento.
-    Contiene varias frases para la segmentación de texto.
-
-    --- Chunk 2 ---
-    Metadata: {'chunk_num': 2, 'span': (83, 196)}
-    Content: El segundo ejemplo es más extenso para probar el procesamiento por lotes.
-    La tercera oración añade más contenido.
-
-    --- Chunk 3 ---
-    Metadata: {'chunk_num': 3, 'span': (197, 236)}
-    Content: Y la cuarta oración para mayor medida.
-
-    --- Chunk 4 ---
-    Metadata: {'chunk_num': 1, 'span': (0, 96)}
+    Metadata: {'chunk_num': 1, 'span': (0, 79)}
     Content: This is the first document.
     It has multiple sentences for chunking.
     Here is the second document.
 
-    --- Chunk 5 ---
-    Metadata: {'chunk_num': 2, 'span': (97, 201)}
-    Content: It is a bit longer to test batch processing effectively.
-    This is the third sentence to add more content.
-
-    --- Chunk 6 ---
-    Metadata: {'chunk_num': 3, 'span': (202, 294)}
-    Content: And the fourth sentence for good measure.
-    The fifth sentence makes it even more interesting.
+    --- Chunk 2 ---
+    Metadata: {'chunk_num': 1, 'span': (0, 69)}
+    Content: Este es el primer documento.
+    Contiene varias frases para la segmentación de texto.
     ```
 
 ### For Files
@@ -508,11 +403,10 @@ The `separator` parameter works for both `chunk_texts` and `chunk_files`. It let
 !!! note "Quick Note"
     `None` won't work as a separator - you'll need something more substantial!
 
-```py linenums="1" hl_lines="2 9 14 18-21"
-from chunklet.document_chunker import DocumentChunker
+```py linenums="1" hl_lines="3 8 12 16-20"
 from more_itertools import split_at
 
-chunker = DocumentChunker()
+chunker = DocumentChunker(max_sentences=1)
 texts = [
     "This is the first document. It has two sentences.",
     "This is the second document. It also has two sentences."
@@ -521,7 +415,6 @@ custom_separator = "---END_OF_DOCUMENT---"
 
 chunks_with_separators = chunker.chunk_texts(
     texts,
-    max_sentences=1,
     separator=custom_separator,
     show_progress=False,
 )
@@ -571,7 +464,7 @@ To use a custom processor, you leverage the [`@registry.register`](../../referen
     - For multi-section documents, return a list of strings - each will be processed as a separate section
     - If an error occurs during the document processing (e.g., an issue with the custom processor function), a [`CallbackError`](../../exceptions-and-warnings.md#callbackerror) will be raised
 
-```py linenums="1" hl_lines="5-7 9-19 21 53-54"
+```py linenums="1" hl_lines="5-7 9-19 21 44-48 50-51"
 import os
 import re
 import json
@@ -592,9 +485,9 @@ def my_json_processor(file_path: str) -> tuple[str, dict]:
     metadata["source"] = file_path
     return text_content, metadata
 
-chunker = DocumentChunker(processor_registry=registry)
+chunker = DocumentChunker(processor_registry=registry, max_sentences=5)
 
-# A longer and more complex JSON sample
+# A complex JSON sample
 json_data = {
     "metadata": {
         "document_id": "doc-12345",
@@ -613,10 +506,7 @@ with tempfile.NamedTemporaryFile(mode='w+', suffix=".json") as tmp:
     tmp.seek(0)
     tmp_path = tmp.name
 
-    chunks = chunker.chunk_file(
-        path=tmp_path,
-        max_sentences=5,
-    )
+    chunks = chunker.chunk_file(path=tmp_path)
 
     for i, chunk in enumerate(chunks):
         print(f"--- Chunk {i+1} ---")
@@ -639,30 +529,22 @@ registry.unregister(".json")
     Finally, the third paragraph concludes our sample.
 
     Metadata:
-    {'document_id': 'doc-12345', 'created_at': '2025-11-05', 'source': '/tmp/tmpdt6xa5rh.json', 'chunk_num': 1, 'span': (0, 292)}
+    {'document_id': 'doc-12345', 'created_at': '2025-11-05', 'source': '/tmp/tmpdt6xa5rh.json', 'chunk_num': 1, 'span': (0, 242)}
 
     --- Chunk 2 ---
     Content:
     ... the third paragraph concludes our sample.
+    We hope this demonstrates the flexibility of the system in handling various data formats.
 
     Metadata:
-    {'document_id': 'doc-12345', 'created_at': '2025-11-05', 'source': '/tmp/tmpdt6xa5rh.json', 'chunk_num': 2, 'span': (250, 292)}
+    {'document_id': 'doc-12345', 'created_at': '2025-11-05', 'source': '/tmp/tmpdt6xa5rh.json', 'chunk_num': 2, 'span': (250, 361)}
     ```
 
 !!! note "Registering Without the Decorator"
     If you prefer not to use decorators, you can directly use the `registry.register()` method. This is particularly useful when registering processors dynamically.
 
-    ```py linenums="1"
-    from chunklet.document_chunker import CustomProcessorRegistry, DocumentChunker
-
-    registry = CustomProcessorRegistry()
-
-    def my_other_processor(file_path: str) -> tuple[str, dict]:
-        # ... your logic ...
-        return "some text", {"source": file_path}
-
+    ```py
     registry.register(my_other_processor, ".custom", name="MyOtherProcessor")
-    chunker = DocumentChunker(processor_registry=registry)
     ```
 
 !!! tip "Per-Instance Scope"

--- a/docs/getting-started/programmatic/sentence_splitter.md
+++ b/docs/getting-started/programmatic/sentence_splitter.md
@@ -41,7 +41,7 @@ Robots are learning. It's raining. Let's code. Mars is red. Sr. sleep is rare. C
 """
 
 splitter = SentenceSplitter(verbose=True, lang="auto")
-sentences = splitter.split_text(TEXT) #(1)!
+sentences = splitter.split_text(TEXT)  # (1)!
 
 for sentence in sentences:
     print(sentence)
@@ -86,7 +86,7 @@ splitter = SentenceSplitter(lang="en")
 sentences = splitter.split_file("sample.txt")
 
 for i, sentence in enumerate(sentences):
-    print(f"Sentence {i+1}: {sentence}")
+    print(f"Sentence {i + 1}: {sentence}")
 ```
 
 ??? success "Click to show output"
@@ -108,7 +108,7 @@ lang_texts = {
     "fr": "Ceci est une phrase. Voici une autre phrase. M. Smith est allé à Washington. Il a dit 'Bonjour le monde!'. Le renard brun et rapide saute par-dessus le chien paresseux.",
     "es": "Esta es una oración. Aquí hay otra oración. El Sr. Smith fue a Washington. Dijo '¡Hola Mundo!'. El rápido zorro marrón salta sobre el perro perezoso.",
     "de": "Dies ist ein Satz. Hier ist ein weiterer Satz. Herr Smith ging nach Washington. Er sagte 'Hallo Welt!'. Der schnelle braune Fuchs springt über den faulen Hund.",
-    "hi": "यह एक वाक्य है। यह एक और वाक्य है। श्री स्मिथ वाशिंगटन गए। उसने कहा 'नमस्ते दुनिया!'। तेज भूरा लोमड़ी आलसी कुत्ते पर कूदता है।"
+    "hi": "यह एक वाक्य है। यह एक और वाक्य है। श्री स्मिथ वाशिंगटन गए। उसने कहा 'नमस्ते दुनिया!'। तेज भूरा लोमड़ी आलसी कुत्ते पर कूदता है।",
 }
 
 splitter = SentenceSplitter()

--- a/docs/getting-started/programmatic/sentence_splitter.md
+++ b/docs/getting-started/programmatic/sentence_splitter.md
@@ -40,14 +40,14 @@ The Playlist contains:
 Robots are learning. It's raining. Let's code. Mars is red. Sr. sleep is rare. Consider item 1. This is a test. The year is 2025. This is a good year since N.A.S.A. reached 123.4 light year more.
 """
 
-splitter = SentenceSplitter(verbose=True)
-sentences = splitter.split_text(TEXT, lang="auto") #(1)!
+splitter = SentenceSplitter(verbose=True, lang="auto")
+sentences = splitter.split_text(TEXT) #(1)!
 
 for sentence in sentences:
     print(sentence)
 ```
 
-1.  **Auto language detection**: Let the splitter automatically detect the language of your text. For best results, specify a language code like `"en"` or `"fr"` directly.
+1.  **Auto language detection**: Let the splitter automatically detect the language of your text by setting `lang="auto"` in the constructor. For best results, specify a language code like `"en"` or `"fr"` directly in the constructor.
 
 ??? success "Click to show output"
     ```linenums="0"
@@ -82,8 +82,8 @@ Need to split a file directly into sentences? Use `split_file`:
 ``` py linenums="1"
 from chunklet.sentence_splitter import SentenceSplitter
 
-splitter = SentenceSplitter()
-sentences = splitter.split_file("sample.txt", lang="en")
+splitter = SentenceSplitter(lang="en")
+sentences = splitter.split_file("sample.txt")
 
 for i, sentence in enumerate(sentences):
     print(f"Sentence {i+1}: {sentence}")

--- a/docs/getting-started/programmatic/visualizer.md
+++ b/docs/getting-started/programmatic/visualizer.md
@@ -37,8 +37,8 @@ from chunklet.visualizer import Visualizer
 #     return len(text.split())  # Simple word-based counting
 
 visualizer = Visualizer(
-    host="127.0.0.1",    #(1)!
-    port=8000,          #(2)!
+    host="127.0.0.1",  # (1)!
+    port=8000,  # (2)!
     # token_counter=my_token_counter  # Uncomment if using custom counter
 )
 
@@ -218,7 +218,7 @@ Use this Python client to chunk files programmatically:
         files = {"file": ("my_document.txt", f, "text/plain")}
         data = {
             "mode": "document",  # or "code"
-            "params": '{"max_sentences": 3, "overlap_percent": 20}'
+            "params": '{"max_sentences": 3, "overlap_percent": 20}',
         }
 
         response = requests.post(f"{base_url}/api/chunk", files=files, data=data)
@@ -249,12 +249,11 @@ Use this Python client to chunk files programmatically:
 
     with open("my_document.txt", "rb") as f:
         files = {"file": ("my_document.txt", f, "text/plain")}
-        data = {
-            "mode": "document",
-            "params": '{"max_sentences": 3, "overlap_percent": 20}'
-        }
+        data = {"mode": "document", "params": '{"max_sentences": 3, "overlap_percent": 20}'}
 
-        response = requests.post(f"{base_url}/api/chunk", files=files, data=data, headers=headers)
+        response = requests.post(
+            f"{base_url}/api/chunk", files=files, data=data, headers=headers
+        )
 
     if response.status_code == 200:
         result = msgpack.unpackb(response.content, raw=False)

--- a/docs/how-to/custom-tokenizer.md
+++ b/docs/how-to/custom-tokenizer.md
@@ -131,9 +131,11 @@ chunklet visualize \
 ```python linenums="1"
 from chunklet import DocumentChunker
 
+
 # Your custom tokenizer function
 def my_tokenizer(text: str) -> int:
     return len(text.split())  # Simple word count!
+
 
 chunker = DocumentChunker(token_counter=my_tokenizer)
 chunks = chunker.chunk_text(text, max_tokens=50)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -74,6 +74,39 @@ The names deprecated in v2.2.0 are gone in v3. If you were still using them, her
 
 If you were already calling the `chunk_text`/`chunk_texts`/`split_text` methods, nothing changes for you.
 
+### Constraints moved to the constructor
+
+Sizing and tuning parameters (`max_tokens`, `max_sentences`, `max_section_breaks`, `overlap_percent`, `offset`, `lang`) used to be passed per call to `chunk_text()`, `chunk_file()`, `chunk_texts()`, `chunk_files()`, `split_text()`, and `split_file()`. They now live on the chunker/splitter instance, set once at construction and mutable as plain attributes. The same applies to `CodeChunker` (`max_tokens`, `max_lines`, `max_functions`) and `SentenceSplitter` (`lang`).
+
+=== "Before"
+
+    ```py
+    chunker = DocumentChunker()
+    chunks = chunker.chunk_text(
+        text,
+        lang="auto",
+        max_sentences=3,
+        max_tokens=500,
+        max_section_breaks=2,
+        overlap_percent=20,
+        offset=0,
+    )
+    ```
+
+=== "After"
+
+    ```py
+    chunker = DocumentChunker(
+        lang="auto",
+        max_sentences=3,
+        max_tokens=500,
+        max_section_breaks=2,
+        overlap_percent=20,
+        offset=0,
+    )
+    chunks = chunker.chunk_text(text)
+    ```
+
 ---
 
 ## Coming from v1

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -35,9 +35,10 @@ In v2, custom processors lived on a **global** `custom_processor_registry` singl
     ```py
     from chunklet.document_chunker import DocumentChunker, custom_processor_registry
 
+
     @custom_processor_registry.register(".json", name="MyJSONProcessor")
-    def my_json_processor(file_path: str) -> tuple[str, dict]:
-        ...
+    def my_json_processor(file_path: str) -> tuple[str, dict]: ...
+
 
     chunker = DocumentChunker()
     ```
@@ -49,9 +50,10 @@ In v2, custom processors lived on a **global** `custom_processor_registry` singl
 
     registry = CustomProcessorRegistry()
 
+
     @registry.register(".json", name="MyJSONProcessor")
-    def my_json_processor(file_path: str) -> tuple[str, dict]:
-        ...
+    def my_json_processor(file_path: str) -> tuple[str, dict]: ...
+
 
     chunker = DocumentChunker(processor_registry=registry)
     ```

--- a/tests/test_plain_text_chunking.py
+++ b/tests/test_plain_text_chunking.py
@@ -1,7 +1,7 @@
 import re
+from textwrap import dedent
 
 import pytest
-from textwrap import dedent
 from more_itertools import split_at
 
 from chunklet import (


### PR DESCRIPTION
## Summary

Chunker constraints moved from per-call arguments to the constructor. `max_tokens`, `max_sentences`, `max_section_breaks`, `overlap_percent`, `offset`, `lang`, `max_lines`, and `max_functions` now live on the chunker instance, set once at `__init__` and mutable as plain attributes. This branch is docs-only — the code changes are on `refactor/init-constraints`.

## What Changed

- `document_chunker.md`: every example now uses the constructor API. Output blocks regenerated against the shortened sample text. Added `overlap_percent`, `offset`, and `lang` to the constraints table. The combining example is self-sufficient with `token_counter`, and the section-breaks example uses a fresh `DocumentChunker(max_section_breaks=2)`.
- `code_chunker.md`: same treatment: constructor API throughout, output blocks regenerated, batch and separator examples updated.
- `sentence_splitter.md`: `lang` moved to the constructor for `split_text` and `split_file`.
- `visualizer.md`, `README.md`, `custom-tokenizer.md` — ruff formatting pass.
- `migration.md`: new "Constraints moved to the constructor" section with before/after examples.
- `audit_migration.py`: now flags moved-to-constructor arguments, not just removed ones.
- Batch ordering documented that `chunk_texts`/`chunk_files` with `n_jobs > 1` yields chunks in non-deterministic order. `separator` grouping stays deterministic.




---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>