### PR TITLE
Internal code cleanup and lint fixes

### DIFF
--- a/src/chunklet/cli.py
+++ b/src/chunklet/cli.py
@@ -315,7 +315,7 @@ def split_command(
             f"Error: {e}",
             err=True,
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=1) from None
 
     if source:
         sentences = splitter.split_file(source)

--- a/src/chunklet/document_chunker/processors/pptx_processor.py
+++ b/src/chunklet/document_chunker/processors/pptx_processor.py
@@ -166,8 +166,7 @@ class PPTXProcessor(BaseProcessor):
         parts.append("")
         return "\n".join(parts)
 
-    @staticmethod
-    def _safe_chart_title(chart: Any) -> str | None:
+    def _safe_chart_title(self, chart: Any) -> str | None:
         """Extract chart title text safely, avoiding missing-attribute errors."""
         title = getattr(chart, "chart_title", None)
         if not title or not hasattr(title, "has_text_frame"):
@@ -177,8 +176,7 @@ class PPTXProcessor(BaseProcessor):
         text = title.text_frame.text.strip()
         return text or None
 
-    @staticmethod
-    def _plot_to_table(plot: Any) -> list[list[str]] | None:
+    def _plot_to_table(self, plot: Any) -> list[list[str]] | None:
         """Build a list-of-lists table (header + rows) from a chart plot."""
         if not (categories := getattr(plot, "categories", None)):
             return None
@@ -238,6 +236,27 @@ class PPTXProcessor(BaseProcessor):
                 return "\n***\n**Notes:**\n" + "\n".join(notes_lines).rstrip(">")
         return None
 
+    def _extract_layout_blocks(self, slide: Any) -> list[str]:
+        """Extract markdown blocks from the slide's layout shapes.
+
+        Args:
+            slide: A python-pptx Slide object.
+
+        Returns:
+            A list of markdown string blocks for each shape in the slide layout.
+        """
+        blocks: list[str] = []
+        for shape in slide.shapes:
+            if shape == slide.shapes.title:
+                continue
+            if table_md := self._extract_table(shape):
+                blocks.append(table_md)
+            if chart_md := self._extract_chart(shape):
+                blocks.append(chart_md)
+            if text_md := self._extract_text(shape):
+                blocks.append(text_md)
+        return blocks
+
     def extract_metadata(self) -> dict[str, Any]:
         """
         Extracts OpenXML Document CoreProperties from the PPTX file
@@ -275,15 +294,7 @@ class PPTXProcessor(BaseProcessor):
                 slide_content.append(title)
 
             # Layout blocks
-            for shape in slide.shapes:
-                if shape == slide.shapes.title:
-                    continue
-                if table_md := self._extract_table(shape):
-                    slide_content.append(table_md)
-                if chart_md := self._extract_chart(shape):
-                    slide_content.append(chart_md)
-                if text_md := self._extract_text(shape):
-                    slide_content.append(text_md)
+            slide_content.extend(self._extract_layout_blocks(slide))
 
             # Presenter Notes
             if notes_md := self._extract_notes(slide):

--- a/src/chunklet/sentence_splitter/sentence_splitter.py
+++ b/src/chunklet/sentence_splitter/sentence_splitter.py
@@ -54,6 +54,31 @@ class SentenceSplitter:
         # Tracked to reduce log spamming about language detection
         self._last_lang_used = None
 
+    def _get_lang_identifier(self):
+        """
+        Lazily build and cache the py3langid LanguageIdentifier used for detection.
+
+        Returns:
+            The cached LanguageIdentifier instance.
+
+        Raises:
+            ImportError: If py3langid is not installed.
+        """
+        if not self._lang_identifier:
+            try:
+                from py3langid.langid import MODEL_FILE, LanguageIdentifier
+
+                self._lang_identifier = LanguageIdentifier.from_model_file(
+                    MODEL_FILE, norm_probs=True
+                )
+            except ImportError as e:  # pragma: no cover
+                raise ImportError(
+                    "The 'py3langid' library is required for auto language detection. "
+                    "Please install it with 'pip install 'py3langid>=0.4.0,<0.5.0'' "
+                    "or install the auto extra with 'pip install 'chunklet-py[auto]''"
+                ) from e
+        return self._lang_identifier
+
     @staticmethod
     @lru_cache(maxsize=52)
     def _get_lang_handler(lang: str, verbose: bool) -> Callable | None:
@@ -131,22 +156,7 @@ class SentenceSplitter:
         Returns:
             A tuple containing the detected language code and its confidence.
         """
-        if not self._lang_identifier:
-            # Create a normalized identifier for language detection
-            try:
-                from py3langid.langid import MODEL_FILE, LanguageIdentifier
-
-                self._lang_identifier = LanguageIdentifier.from_model_file(
-                    MODEL_FILE, norm_probs=True
-                )
-            except ImportError as e:  # pragma: no cover
-                raise ImportError(
-                    "The 'py3langid' library is required for auto language detection. "
-                    "Please install it with 'pip install 'py3langid>=0.4.0,<0.5.0'' "
-                    "or install the auto extra with 'pip install 'chunklet-py[auto]''"
-                ) from e
-
-        lang_detected, confidence = self._lang_identifier.classify(text)
+        lang_detected, confidence = self._get_lang_identifier().classify(text)
         log_info(
             self.verbose,
             "Language detection: '{}' with confidence {}.",

--- a/tests/test_plain_text_chunking.py
+++ b/tests/test_plain_text_chunking.py
@@ -4,8 +4,6 @@ from textwrap import dedent
 import pytest
 from more_itertools import split_at
 
-LANG = "en"
-
 from chunklet import (
     CallbackError,
     InvalidInputError,
@@ -14,6 +12,8 @@ from chunklet import (
 from chunklet.document_chunker import DocumentChunker
 from chunklet.document_chunker._plain_text_chunker import SECTION_BREAK_PATTERN
 from chunklet.sentence_splitter import SentenceSplitter
+
+LANG = "en"
 
 # --- Constants ---
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -88,7 +88,7 @@ def visualizer_server():
     url = f"http://{host}:{port}"  # noqa: S310
     wait_for_server(url)
 
-    yield {
+    return {
         "url": url,
         "host": host,
         "port": port,


### PR DESCRIPTION
## Summary

Internal cleanup, no behavior change. This tightens up a few code paths and quiets the linter so the diff stays reviewable and future work is easier to land.

## What Changed

- Extracted the lazy py3langid identifier construction in `SentenceSplitter` into a dedicated `_get_lang_identifier()` method
- Pulled slide shape extraction out of `extract_text` in the PPTX processor into `_extract_layout_blocks()`, and converted the two stateless chart helpers to instance methods
- Swapped the visualizer test fixture from `yield` to `return` (it has no teardown)
- Fixed two lint violations: `B904` on a CLI `raise ... Exit` inside an `except` block and `E402` on imports after a constant in a test file

## Testing

All 78 tests pass. `ruff check` and `ruff format --check` are clean across the repo.