### PR TITLE
Make language detection a private standalone utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Document processor registry global**: Removed the global `custom_processor_registry` singleton. `CustomProcessorRegistry` is now a plain instance you create and pass to `DocumentChunker(processor_registry=...)`.
 - **`sentence_splitter` constructor parameter**: Removed from `DocumentChunker` and `PlainTextChunker`; both now always use a default `SentenceSplitter`.
 - **Hard dependency on `py3langid` and `indic-nlp-library`**: No longer installed by default. Both pulled in heavy dependencies (`numpy`, `pandas`, `morfessor`) that most users don't need. They're now optional extras and this significantly reduces the default install size.
+- **`SentenceSplitter.detected_top_language()`**: Removed as a public method. Language detection is now the standalone `detect_top_language()` in `chunklet.common.lang_detection`. (Before v2 it lived in `chunklet.utils` as `detect_text_language`.)
 
 ---
 

--- a/audit_migration.py
+++ b/audit_migration.py
@@ -30,10 +30,17 @@ MOVED_TO_CONSTRUCTOR = {
     "max_functions": "Move to the constructor: `CodeChunker(max_functions=...)`.",
 }
 
-CHUNKER_CLASS_NAMES = {"Chunklet", "PlainTextChunker", "DocumentChunker", "CodeChunker"}
+# Classes whose instances the audit tracks to flag legacy method calls on them.
+TRACKED_CLASS_NAMES = {
+    "Chunklet",
+    "PlainTextChunker",
+    "DocumentChunker",
+    "CodeChunker",
+    "SentenceSplitter",
+}
 
 LEGACY_IMPORTS = {
-    "chunklet.utils.detect_text_language": "Use 'SentenceSplitter.detected_top_language()' instead.",
+    "chunklet.utils.detect_text_language": "Use 'detect_top_language' from 'chunklet.common.lang_detection' instead.",
     "chunklet.sentence_splitter.custom_splitter_registry": "Removed in v3. Custom splitters are gone.",
     "chunklet.sentence_splitter.CustomSplitterRegistry": "Removed in v3. Custom splitters are gone.",
     "chunklet.sentence_splitter.BaseSplitter": "Removed in v3.",
@@ -44,6 +51,9 @@ LEGACY_IMPORTS = {
 }
 # Module-level names (not necessarily dotted-import paths) that are gone in v3.
 LEGACY_MODULE_NAMES = {
+    "detect_text_language": (
+        "Use 'detect_top_language' from 'chunklet.common.lang_detection' instead."
+    ),
     "custom_splitter_registry": "Removed in v3. Custom splitters are gone.",
     "CustomSplitterRegistry": "Removed in v3. Custom splitters are gone.",
     "BaseSplitter": "Removed in v3.",
@@ -60,6 +70,7 @@ LEGACY_METHODS = {
     "chunk": "Use 'chunk_text()' or 'chunk_file()' instead.",
     "preview_sentences": "Use 'SentenceSplitter.split_text()' instead.",
     "batch_chunk": "Use 'chunk_texts()' or 'chunk_files()' instead.",
+    "detected_top_language": "Use 'detect_top_language' from 'chunklet.common.lang_detection' instead.",
 }
 
 
@@ -141,22 +152,22 @@ class MigrationAuditor:
         except IndexError:
             return ""
 
-    def _is_chunker_call(self, node: ast.AST) -> bool:
-        """Check if a node is a call to a known chunker class."""
+    def _is_tracked_call(self, node: ast.AST) -> bool:
+        """Check if a node is a call to a known tracked class."""
         if not isinstance(node, ast.Call):
             return False
         if not isinstance(node.func, ast.Name):
             return False
-        return node.func.id in CHUNKER_CLASS_NAMES
+        return node.func.id in TRACKED_CLASS_NAMES
 
     def _get_chunker_instances(self, tree: ast.AST) -> set:
-        """Find all chunker class instantiations in the AST."""
+        """Find all tracked class instantiations in the AST."""
         return {
             target.id
             for node in ast.walk(tree)
             if isinstance(node, ast.Assign)
             and isinstance(node.value, ast.Call)
-            and self._is_chunker_call(node.value)
+            and self._is_tracked_call(node.value)
             for target in node.targets
             if isinstance(target, ast.Name)
         }
@@ -288,7 +299,9 @@ class MigrationAuditor:
 
             if method_name in LEGACY_METHODS:
                 style = (
-                    "bold red" if method_name in ("preview_sentences",) else "yellow"
+                    "bold red"
+                    if method_name in ("preview_sentences", "detected_top_language")
+                    else "yellow"
                 )
                 self._has_legacy_issues = True
                 self._print_issue(

--- a/docs/getting-started/programmatic/sentence_splitter.md
+++ b/docs/getting-started/programmatic/sentence_splitter.md
@@ -61,7 +61,7 @@ for sentence in sentences:
 ??? success "Click to show output"
     ```linenums="0"
     2025-11-02 16:27:29.277 | WARNING  | chunklet.sentence_splitter.sentence_splitter:split_text:192 - The language is set to `auto`. Consider setting the `lang` parameter to a specific language to improve reliability.
-    2025-11-02 16:27:29.316 | INFO     | chunklet.sentence_splitter.sentence_splitter:detected_top_language:146 - Language detection: 'en' with confidence 10/10.
+    2025-11-02 16:27:29.316 | INFO     | chunklet.sentence_splitter.sentence_splitter:split_text:158 - Language detection: 'en' with confidence 10/10.
     2025-11-02 16:27:29.447 | INFO     | chunklet.sentence_splitter.sentence_splitter:split_text:166 - Text splitted into sentences. Total sentences detected: 19
     She loves cooking.
     He studies AI.
@@ -103,49 +103,6 @@ for i, sentence in enumerate(sentences):
     Sentence 1: This is the first sentence.
     Sentence 2: This is the second sentence.
     Sentence 3: And the third.
-    ```
-
-### Detecting Top Languages 🎯
-
-Here's how you can detect the top language of a given text using the `SentenceSplitter`:
-
-``` py linenums="1"
-from chunklet.sentence_splitter import SentenceSplitter
-
-lang_texts = {
-    "en": "This is a sentence. This is another sentence. Mr. Smith went to Washington. He said 'Hello World!'. The quick brown fox jumps over the lazy dog.",
-    "fr": "Ceci est une phrase. Voici une autre phrase. M. Smith est allé à Washington. Il a dit 'Bonjour le monde!'. Le renard brun et rapide saute par-dessus le chien paresseux.",
-    "es": "Esta es una oración. Aquí hay otra oración. El Sr. Smith fue a Washington. Dijo '¡Hola Mundo!'. El rápido zorro marrón salta sobre el perro perezoso.",
-    "de": "Dies ist ein Satz. Hier ist ein weiterer Satz. Herr Smith ging nach Washington. Er sagte 'Hallo Welt!'. Der schnelle braune Fuchs springt über den faulen Hund.",
-    "hi": "यह एक वाक्य है। यह एक और वाक्य है। श्री स्मिथ वाशिंगटन गए। उसने कहा 'नमस्ते दुनिया!'। तेज भूरा लोमड़ी आलसी कुत्ते पर कूदता है।",
-}
-
-splitter = SentenceSplitter(lang="auto")
-
-for lang, text in lang_texts.items():
-    detected_lang, confidence = splitter.detected_top_language(text)
-    print(f"Original language: {lang}")
-    print(f"Detected language: {detected_lang} with confidence {confidence:.2f}")
-    print("-" * 20)
-```
-
-??? success "Click to show output"
-    ```linenums="0"
-    Original language: en
-    Detected language: en with confidence 1.00
-    --------------------
-    Original language: fr
-    Detected language: fr with confidence 1.00
-    --------------------
-    Original language: es
-    Detected language: es with confidence 1.00
-    --------------------
-    Original language: de
-    Detected language: de with confidence 1.00
-    --------------------
-    Original language: hi
-    Detected language: hi with confidence 1.00
-    --------------------
     ```
 
 ??? info "API Reference"

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -105,6 +105,38 @@ If you only ever used specific language codes like `lang="en"`, you don't need t
     pip install 'chunklet-py[auto]'
     ```
 
+### Language detection moved to `common`
+
+Language detection is no longer a method on `SentenceSplitter`. It's now a standalone function at `chunklet.common.lang_detection.detect_top_language()`, so you can call it without constructing a splitter.
+
+This affects two ways you may have used it before:
+
+- The legacy `chunklet.utils.detect_text_language()` from v1/v2.
+- `SentenceSplitter.detected_top_language()` from v2.
+
+=== "Before (v2.x.x)"
+
+    ```py
+    from chunklet.sentence_splitter import SentenceSplitter
+
+    splitter = SentenceSplitter(lang="auto")
+    lang_code, confidence = splitter.detected_top_language(text)
+    ```
+
+=== "After (v3.x.x)"
+
+    ```py
+    from chunklet.common.lang_detection import detect_top_language
+
+    lang_code, confidence = detect_top_language(text)
+    ```
+
+It still needs `py3langid`, so install the extra if you haven't:
+
+```bash
+pip install 'chunklet-py[auto]'
+```
+
 ### Constraints moved to the constructor
 
 Sizing and tuning parameters (`max_tokens`, `max_sentences`, `max_section_breaks`, `overlap_percent`, `offset`, `lang`) used to be passed per call to `chunk_text()`, `chunk_file()`, `chunk_texts()`, `chunk_files()`, `split_text()`, and `split_file()`. They now live on the chunker/splitter instance, set once at construction and mutable as plain attributes. The same applies to `CodeChunker` (`max_tokens`, `max_lines`, `max_functions`) and `SentenceSplitter` (`lang`).

--- a/src/chunklet/cli.py
+++ b/src/chunklet/cli.py
@@ -27,6 +27,7 @@ try:
 except ImportError:  # pragma: no cover
     Visualizer = None
 
+from chunklet.common.lang_detection import detect_top_language
 from chunklet.common.path_utils import is_path_like
 
 try:
@@ -319,12 +320,12 @@ def split_command(
 
     if source:
         sentences = splitter.split_file(source)
-        lang_detected, confidence = splitter.detected_top_language(
+        lang_detected, confidence = detect_top_language(
             source.read_text(encoding="utf-8")
         )
     else:
         sentences = splitter.split_text(input_text)
-        lang_detected, confidence = splitter.detected_top_language(input_text)
+        lang_detected, confidence = detect_top_language(input_text)
 
     # Output Handling
     if destination:

--- a/src/chunklet/common/lang_detection.py
+++ b/src/chunklet/common/lang_detection.py
@@ -1,0 +1,36 @@
+from typing import Callable
+
+# Lazy global cache for the py3langid LanguageIdentifier.
+_lang_identifier: Callable | None = None
+
+
+def detect_top_language(text: str) -> tuple[str, float]:
+    """Detect the top language of the given text using py3langid.
+
+    The LanguageIdentifier is built lazily on first use and cached for reuse.
+
+    Args:
+        text: The input text to detect the language for.
+
+    Returns:
+        A tuple containing the detected language code and its confidence.
+
+    Raises:
+        ImportError: If py3langid is not installed.
+    """
+    global _lang_identifier
+    if _lang_identifier is None:
+        try:
+            from py3langid.langid import MODEL_FILE, LanguageIdentifier
+
+            _lang_identifier = LanguageIdentifier.from_model_file(
+                MODEL_FILE, norm_probs=True
+            )
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "The 'py3langid' library is required for auto language detection. "
+                "Please install it with 'pip install 'py3langid>=0.4.0,<0.5.0'' "
+                "or install the auto extra with 'pip install 'chunklet-py[auto]''"
+            ) from e
+
+    return _lang_identifier.classify(text)

--- a/src/chunklet/sentence_splitter/sentence_splitter.py
+++ b/src/chunklet/sentence_splitter/sentence_splitter.py
@@ -6,6 +6,7 @@ from typing import Callable
 from loguru import logger
 
 # yasbd, indicnlp, sentencex and py3langid are lazy imported
+from chunklet.common.lang_detection import detect_top_language
 from chunklet.common.logging_utils import log_info
 from chunklet.common.path_utils import read_text_file
 from chunklet.common.validation import validate_input
@@ -49,35 +50,9 @@ class SentenceSplitter:
         self.verbose = verbose
         self.fallback_splitter = UniversalSplitter()
         self.lang = lang
-        self._lang_identifier = None
 
         # Tracked to reduce log spamming about language detection
         self._last_lang_used = None
-
-    def _get_lang_identifier(self):
-        """
-        Lazily build and cache the py3langid LanguageIdentifier used for detection.
-
-        Returns:
-            The cached LanguageIdentifier instance.
-
-        Raises:
-            ImportError: If py3langid is not installed.
-        """
-        if not self._lang_identifier:
-            try:
-                from py3langid.langid import MODEL_FILE, LanguageIdentifier
-
-                self._lang_identifier = LanguageIdentifier.from_model_file(
-                    MODEL_FILE, norm_probs=True
-                )
-            except ImportError as e:  # pragma: no cover
-                raise ImportError(
-                    "The 'py3langid' library is required for auto language detection. "
-                    "Please install it with 'pip install 'py3langid>=0.4.0,<0.5.0'' "
-                    "or install the auto extra with 'pip install 'chunklet-py[auto]''"
-                ) from e
-        return self._lang_identifier
 
     @staticmethod
     @lru_cache(maxsize=52)
@@ -146,26 +121,6 @@ class SentenceSplitter:
         return processed_sentences
 
     @validate_input
-    def detected_top_language(self, text: str) -> tuple[str, float]:
-        """
-        Detects the top language of the given text using py3langid.
-
-        Args:
-            text: The input text to detect the language for.
-
-        Returns:
-            A tuple containing the detected language code and its confidence.
-        """
-        lang_detected, confidence = self._get_lang_identifier().classify(text)
-        log_info(
-            self.verbose,
-            "Language detection: '{}' with confidence {}.",
-            lang_detected,
-            f"{round(confidence) * 10}/10",
-        )
-        return lang_detected, confidence
-
-    @validate_input
     def split_text(self, text: str) -> list[str]:
         """
         Splits a given text into a list of sentences.
@@ -199,7 +154,13 @@ class SentenceSplitter:
                     "The language is set to `auto`. Consider setting the `lang` parameter "
                     "to a specific language to improve reliability."
                 )
-            lang_detected, confidence = self.detected_top_language(text)
+            lang_detected, confidence = detect_top_language(text)
+            log_info(
+                self.verbose,
+                "Language detection: '{}' with confidence {}.",
+                lang_detected,
+                f"{round(confidence) * 10}/10",
+            )
             lang = lang_detected if confidence >= 0.7 else "fallback"
 
         self._last_lang_used = lang


### PR DESCRIPTION
## Summary

Make language detection a private, standalone utility instead of a public method on `SentenceSplitter`. Detection doesn't depend on splitter state, so it doesn't belong on the instance — this also lets callers detect a language without constructing a splitter.

## What Changed

- Added `detect_top_language()` in `chunklet.common.lang_detection` (lazy py3langid construction, cached for reuse)
- Removed the public `SentenceSplitter.detected_top_language()`, `_get_lang_identifier()`, and `_lang_identifier`; `split_text` now calls the utility directly and keeps its verbose log
- Updated the CLI to call the utility instead of the removed splitter method
- Updated migration docs and CHANGELOG to point users at the new location
- Extended the migration auditor to flag both legacy usages: `chunklet.utils.detect_text_language` imports and `SentenceSplitter.detected_top_language()` calls

## Testing

All 78 tests pass and `ruff check` is clean. Verified the migration auditor flags both legacy language-detection patterns.

## Notes for Reviewers

- The shared `_lang_identifier` is now a module-level cache in `lang_detection.py` rather than per-instance state, which is the intended behavior (the identifier is stateless/thread-safe for classification).
- This restores the detection function to a standalone utility, the form it had pre-v2 (when it lived in `chunklet.utils`).
