### PR TITLE
Change visualizer default chunking language from auto to English

### DIFF
--- a/src/chunklet/visualizer/static/index.html
+++ b/src/chunklet/visualizer/static/index.html
@@ -86,8 +86,8 @@
                         <div class="param-group">
                             <label class="param-label" for="language">Language</label>
                             <div class="param-input-group">
-                                <input type="text" id="language" placeholder="auto" maxlength="2" style="text-transform: uppercase;">
-                                <small>ISO 639-1 language code (auto-detect if empty) - e.g., 'en', 'es', 'fr'</small>
+                                <input type="text" id="language" placeholder="en" maxlength="2" style="text-transform: uppercase;">
+                                <small>ISO 639-1 language code - e.g., 'en', 'es', 'fr'. Defaults to 'en'.</small>
                             </div>
                         </div>
                         

--- a/src/chunklet/visualizer/visualizer.py
+++ b/src/chunklet/visualizer/visualizer.py
@@ -88,7 +88,7 @@ class Visualizer:
         # Initialize chunkers with sensible defaults; constraint attributes are
         # mutated per request from the submitted params.
         self.document_chunker = DocumentChunker(
-            lang="auto",
+            lang="en",
             token_counter=token_counter,
             max_sentences=3,
         )

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -198,6 +198,35 @@ def test_chunk_file_json_backward_compatible(visualizer_server):
     assert result["stats"]["chunk_count"] > 1
 
 
+def test_chunk_file_lang_param(visualizer_server):
+    """Test that a lang param submitted from the UI is applied to the chunker."""
+    url = f"{visualizer_server['url']}/api/chunk"
+
+    sample_file_path = Path(__file__).parent.parent / "samples" / "sample_text.txt"
+    assert sample_file_path.exists(), f"Sample file not found: {sample_file_path}"
+
+    data = {
+        "mode": "document",
+        "params": json.dumps({"lang": "fr", "max_sentences": 3}),
+    }
+    response = _multipart_post(
+        url,
+        file_content=sample_file_path.read_bytes(),
+        file_name="sample_text.txt",
+        fields=data,
+        headers=None,
+    )
+    assert response.getcode() == 200
+
+    result = json.loads(response.read().decode())
+    assert result["stats"]["mode"] == "document"
+    assert result["stats"]["chunk_count"] > 0
+
+    # The lang value must have propagated to the shared document chunker via
+    # the backend's setattr loop, not just been accepted for this request.
+    assert visualizer_server["visualizer"].document_chunker.lang == "fr"
+
+
 def test_chunk_file_invalid_format(visualizer_server):
     """Test uploading invalid file format."""
     url = f"{visualizer_server['url']}/api/chunk"


### PR DESCRIPTION
## Summary

The visualizer now defaults document chunking to `lang="en"` instead of `"auto"`. In v3, auto-detection is an opt-in extra, so holding onto `"auto"` meant every upload silently dragged in `py3langid` even when nobody asked for language detection.

## What Changed

- Document chunker defaults to `lang="en"` (was `"auto"`), dropping the implicit `py3langid` requirement
- UI placeholder and hint text updated to match
- Added a test for the `lang` param through the `/api/chunk` endpoint

## Testing

`test_chunk_file_lang_param` posts a document with `lang="fr"` and checks the value lands on the shared document chunker, not just that the request returns 200. Visualizer suite passes (5 tests), `ruff check` clean.