### PR TITLE
Consolidate feature flags to single names and remove aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Visualizer**: The visualizer's document chunker now defaults to `lang="en"` instead of `"auto"`.
 - **`indic-nlp-library` is now an optional extra**: Moved out of the core dependencies into the `[indic]` extra. Install with `pip install 'chunklet-py[indic]'` for Indic language support.
 - **Dependency upper bounds tightened**: Optional-extras dependencies no longer accept blanket `<1.0` bounds. Upper bounds now track the tested versions so future breaking releases are excluded.
+- **Extras consolidated**: The `structured-document` extra is renamed to `struct-doc` (`pip install 'chunklet-py[struct-doc]'`). The `document` alias for it and the `visualization` extra are removed; the `viz` extra now carries the visualizer dependencies directly.
 
 ### Fixed
 - **Plain text chunker**: When a sentence is split mid-way on the token limit, its unfitted remainder now opens the next chunk instead of the full sentence being re-appended on top of the overlap clause. Fixes duplicated clauses and unresolved `(-1, -1)` spans in token-limited chunking.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Want to unlock more Chunklet-py superpowers? Add these optional dependencies bas
 
 *   **Structured Documents:** For handling `.pdf`, `.docx`, `.epub`, `.eml`, `.pptx`, and other document formats:
     ```bash
-    pip install "chunklet-py[structured-document]"
+    pip install "chunklet-py[struct-doc]"
     ```
 *   **Code Chunking:** For Language-agnostic code chunking features:
     ```bash
@@ -143,8 +143,6 @@ Want to unlock more Chunklet-py superpowers? Add these optional dependencies bas
     ```
 *   **Visualization:** For the interactive web-based chunk visualizer:
     ```bash
-    pip install "chunklet-py[visualization]"
-    # Or
     pip install "chunklet-py[viz]"
     ```
 * **All Extras:** To install all optional dependencies:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -37,7 +37,7 @@ Chunklet-py offers optional dependencies to unlock additional functionalities, s
 
 *   **Structured Documents:** For handling `.pdf`, `.docx`, `.epub`, `.eml`, `.pptx`, and other document formats:
     ```bash
-    pip install "chunklet-py[structured-document]"
+    pip install "chunklet-py[struct-doc]"
     ```
 *   **Code Chunking:** For Language-agnostic code chunking features:
     ```bash
@@ -53,8 +53,6 @@ Chunklet-py offers optional dependencies to unlock additional functionalities, s
     ```
 *   **Visualization:** For the interactive web-based chunk visualizer:
     ```bash
-    pip install "chunklet-py[visualization]"
-    # Or
     pip install "chunklet-py[viz]"
     ```
 *   **All Extras:** To install all optional dependencies:

--- a/docs/getting-started/programmatic/document_chunker.md
+++ b/docs/getting-started/programmatic/document_chunker.md
@@ -12,10 +12,10 @@ pip install chunklet-py -U
 
 No extra dependencies needed - `DocumentChunker` is ready to roll right out of the box for plain text! 🚀
 
-For document processing (PDFs, DOCX, EPUB, ODT, Excel, etc.), install the structured-document extra:
+For structured document processing (PDFs, DOCX, EPUB, ODT, Excel, etc.), install the struct-doc extra:
 
 ```bash
-pip install chunklet-py[structured-document]
+pip install chunklet-py[struct-doc]
 ```
 
 This installs all the document processing dependencies needed to handle PDFs, DOCX, EPUB, ODT, Excel, and more! 📚

--- a/docs/getting-started/programmatic/visualizer.md
+++ b/docs/getting-started/programmatic/visualizer.md
@@ -8,7 +8,7 @@
 ## Quick Install
 
 ```bash
-pip install chunklet-py[visualization]
+pip install chunklet-py[viz]
 ```
 
 ## Text Chunk Visualizer: Your Window into the Chunking Abyss
@@ -24,7 +24,7 @@ No more guessing games - see your chunking results in real-time!
 First, make sure you have the visualization dependencies:
 
 ```bash
-pip install "chunklet-py[visualization]"
+pip install "chunklet-py[viz]"
 ```
 
 Here's the basic code to get it running:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -170,6 +170,25 @@ Sizing and tuning parameters (`max_tokens`, `max_sentences`, `max_section_breaks
     chunks = chunker.chunk_text(text)
     ```
 
+### Extras renamed
+
+The `structured-document` extra is renamed to `struct-doc`, and the `document` alias for it is gone. The old `visualization` extra is gone too.
+
+=== "Before (v2.x.x)"
+
+    ```bash
+    pip install 'chunklet-py[structured-document]'
+    pip install 'chunklet-py[document]'
+    pip install 'chunklet-py[visualization]'
+    ```
+
+=== "After (v3.x.x)"
+
+    ```bash
+    pip install 'chunklet-py[struct-doc]'
+    pip install 'chunklet-py[viz]'
+    ```
+
 ---
 
 ## Coming from v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ indic = ["indic-nlp-library>=0.92,<1.0"]
 # Language detection; required for lang="auto"
 auto = ["py3langid>=0.4.0,<0.5.0"]
 
-structured-document = [
+struct-doc = [
   "pdfminer.six>=20250324",
   "python-docx>=1.2.0,<2.0",
   "mammoth>=1.9.1,<2.0",
@@ -74,15 +74,12 @@ structured-document = [
   "openpyxl>=3.1.5,<4.0",
 ]
 
-# Kept for compatibility
-document = ["chunklet-py[structured-document]"]
-
 code = [
   "defusedxml>=0.7.1,<0.8",
   "littletree>=0.8.7,<1.0",
 ]
 
-visualization = [
+viz = [
   "uvicorn>=0.35.0,<0.53",
   "fastapi>=0.116.0,<0.142",
   "python-multipart>=0.0.20,<0.33",
@@ -92,9 +89,7 @@ visualization = [
   "aiofiles==25.1.0",
 ]
 
-viz = ["chunklet-py[visualization]"]
-
-all = ["chunklet-py[structured-document,code,visualization,auto,indic]"]
+all = ["chunklet-py[struct-doc,code,viz,auto,indic]"]
 
 dev = [
   "pytest>=8.3.5",
@@ -111,7 +106,7 @@ docs = [
   "pymdown-extensions>=10.16.1",
 ]
 
-dev-all = ["chunklet-py[dev,docs,structured-document,code,visualization,auto,indic]"]
+dev-all = ["chunklet-py[dev,docs,struct-doc,code,viz,auto,indic]"]
 
 [project.urls]
 Homepage = "https://github.com/speedyk-005/chunklet-py"

--- a/src/chunklet/cli.py
+++ b/src/chunklet/cli.py
@@ -528,7 +528,7 @@ def chunk_command(
         if DocumentChunker is None:
             typer.echo(
                 "Error: DocumentChunker dependencies not available.\n"
-                "Please install with: pip install chunklet-py[structured-document]",
+                "Please install with: pip install chunklet-py[struct-doc]",
                 err=True,
             )
             raise typer.Exit(code=1)
@@ -634,7 +634,7 @@ def visualize_command(
     if Visualizer is None:
         typer.echo(
             "Error: Visualization dependencies not available.\n"
-            "Please install with: pip install chunklet-py[visualization]",
+            "Please install with: pip install chunklet-py[viz]",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/src/chunklet/document_chunker/converters/html_2_md.py
+++ b/src/chunklet/document_chunker/converters/html_2_md.py
@@ -27,7 +27,7 @@ def html_to_md(
         raise ImportError(
             "The 'markdownify' library is not installed. "
             "Please install it with 'pip install markdownify' or install the document processing extras "
-            "with 'pip install 'chunklet-py[structured-document]''"
+            "with 'pip install 'chunklet-py[struct-doc]''"
         )
 
     if raw_text:

--- a/src/chunklet/document_chunker/converters/latex_2_md.py
+++ b/src/chunklet/document_chunker/converters/latex_2_md.py
@@ -21,7 +21,7 @@ def latex_to_md(file_path: str | Path) -> str:
         raise ImportError(
             "The 'pylatexenc' library is not installed. "
             "Please install it with 'pip install 'pylatexenc>=2.10'' or install the document processing extras "
-            "with 'pip install 'chunklet-py[structured-document]''"
+            "with 'pip install 'chunklet-py[struct-doc]''"
         )
 
     with open(file_path, encoding="utf-8", errors="ignore") as f:

--- a/src/chunklet/document_chunker/converters/rst_2_md.py
+++ b/src/chunklet/document_chunker/converters/rst_2_md.py
@@ -22,7 +22,7 @@ def rst_to_md(file_path: str | Path) -> str:
         raise ImportError(
             "The 'docutils' library is not installed. "
             "Please install it with 'pip install 'docutils>=0.21.2'' or install the document processing extras "
-            "with 'pip install 'chunklet-py[structured-document]''"
+            "with 'pip install 'chunklet-py[struct-doc]''"
         )
 
     with open(file_path, "r", encoding="utf-8", errors="ignore") as f:

--- a/src/chunklet/document_chunker/converters/table_2_md.py
+++ b/src/chunklet/document_chunker/converters/table_2_md.py
@@ -29,7 +29,7 @@ def table_to_md(file_path: str | Path) -> str:
                 "The 'openpyxl' library is not installed. "
                 "Please install it with 'pip install openpyxl>=3.1.2' "
                 "or install the document processing extras with "
-                "'pip install chunklet-py[structured-document]'"
+                "'pip install chunklet-py[struct-doc]'"
             ) from e
         wb = load_workbook(file_path, read_only=True)
         sheet = wb.active

--- a/src/chunklet/document_chunker/document_chunker.py
+++ b/src/chunklet/document_chunker/document_chunker.py
@@ -250,7 +250,7 @@ class DocumentChunker(BaseChunker):
                 raise ImportError(
                     "The 'striprtf' library is not installed. "
                     "Please install it with 'pip install 'striprtf>=0.0.29'' or install the document processing extras "
-                    "with 'pip install chunklet-py[structured-document]'"
+                    "with 'pip install chunklet-py[struct-doc]'"
                 )
             return rtf_to_text(content)
         else:  # For .txt, .md, and others handled by simple read

--- a/src/chunklet/document_chunker/processors/docx_processor.py
+++ b/src/chunklet/document_chunker/processors/docx_processor.py
@@ -52,7 +52,7 @@ class DOCXProcessor(BaseProcessor):
             raise ImportError(
                 "The 'python-docx' library is not installed. "
                 "Please install it with 'pip install 'python-docx>=1.2.0'' or install the document processing extras "
-                "with 'pip install 'chunklet-py[structured-document]''"
+                "with 'pip install 'chunklet-py[struct-doc]''"
             ) from e
 
         doc = Document(self.file_path)
@@ -79,7 +79,7 @@ class DOCXProcessor(BaseProcessor):
             raise ImportError(
                 "The 'mammoth' library is not installed. "
                 "Please install it with 'pip install 'mammoth>=1.9.0'' or install the document processing extras "
-                "with 'pip install 'chunklet-py[structured-document]''"
+                "with 'pip install 'chunklet-py[struct-doc]''"
             ) from e
 
         count = 0

--- a/src/chunklet/document_chunker/processors/eml_processor.py
+++ b/src/chunklet/document_chunker/processors/eml_processor.py
@@ -49,7 +49,7 @@ class EmlProcessor(BaseProcessor):
             raise ImportError(
                 "The 'mailparse' library is not installed. "
                 "Please install it with 'pip install mailparse>=1.0.1'. or install the document processing extras "
-                "with 'pip install 'chunklet-py[structured-document]'"
+                "with 'pip install 'chunklet-py[struct-doc]'"
             ) from e
         self._parsed = EmailDecode.open(self.file_path)
 

--- a/src/chunklet/document_chunker/processors/epub_processor.py
+++ b/src/chunklet/document_chunker/processors/epub_processor.py
@@ -48,7 +48,7 @@ class EPUBProcessor(BaseProcessor):
             raise ImportError(
                 "The 'ebooklib' library is not installed. "
                 "Please install it with 'pip install 'ebooklib>=0.19'' or install the document processing extras "
-                "with 'pip install 'chunklet-py[structured-document]''"
+                "with 'pip install 'chunklet-py[struct-doc]''"
             )
         self.file_path = file_path
         self.book = epub.read_epub(file_path)

--- a/src/chunklet/document_chunker/processors/odt_processor.py
+++ b/src/chunklet/document_chunker/processors/odt_processor.py
@@ -38,7 +38,7 @@ class ODTProcessor(BaseProcessor):
             raise ImportError(
                 "The 'odfpy' library is not installed. "
                 "Please install it with 'pip install odfpy>=1.4.1' or install the document processing extras "
-                "with 'pip install chunklet-py[structured-document]'"
+                "with 'pip install chunklet-py[struct-doc]'"
             ) from e
 
         self.file_path = file_path

--- a/src/chunklet/document_chunker/processors/pdf_processor.py
+++ b/src/chunklet/document_chunker/processors/pdf_processor.py
@@ -69,7 +69,7 @@ class PDFProcessor(BaseProcessor):
             raise ImportError(
                 "The 'pdfminer.six' library is not installed. "
                 "Please install it with 'pip install 'pdfminer.six>=20250324'' or install the document processing extras "
-                "with 'pip install 'chunklet-py[structured-document]''"
+                "with 'pip install 'chunklet-py[struct-doc]''"
             ) from e
         self.file_path = file_path
         self.laparams = LAParams(

--- a/src/chunklet/document_chunker/processors/pptx_processor.py
+++ b/src/chunklet/document_chunker/processors/pptx_processor.py
@@ -55,7 +55,7 @@ class PPTXProcessor(BaseProcessor):
             raise ImportError(
                 "The 'python-pptx' library is not installed. "
                 "Please install it with 'pip install python-pptx>=1.0.0' or install the document processing extras "
-                "with 'pip install 'chunklet-py[structured-document]''"
+                "with 'pip install 'chunklet-py[struct-doc]''"
             ) from e
 
         self.prs = Presentation(file_path)

--- a/src/chunklet/visualizer/visualizer.py
+++ b/src/chunklet/visualizer/visualizer.py
@@ -69,14 +69,14 @@ class Visualizer:
             raise ImportError(
                 "The 'fastapi' library is not installed. "
                 "Please install it with 'pip install fastapi>=0.115.12' or install the visualization extras "
-                "with 'pip install 'chunklet-py[visualization]''"
+                "with 'pip install 'chunklet-py[viz]''"
             )
 
         if msgpack is None:
             raise ImportError(
                 "The 'msgpack' library is not installed. "
                 "Please install it with 'pip install msgpack>=1.0.8' or install the visualization extras "
-                "with 'pip install 'chunklet-py[visualization]''"
+                "with 'pip install 'chunklet-py[viz]''"
             )
 
         self.host = host
@@ -171,7 +171,7 @@ class Visualizer:
             raise HTTPException(
                 400,
                 "charset-normalizer library is not available. Please install visualization dependencies."
-                "with 'pip install 'chunklet-py[visualization]''",
+                "with 'pip install 'chunklet-py[viz]''",
             )
 
         content = await file.read()
@@ -242,7 +242,7 @@ class Visualizer:
             raise ImportError(
                 "The 'uvicorn' library is not installed. "
                 "Please install it with 'pip install uvicorn>=0.34.0' or install the visualization extras "
-                "with 'pip install 'chunklet-py[visualization]''"
+                "with 'pip install 'chunklet-py[viz]''"
             )
 
         print(" =" * 20)

--- a/uv.lock
+++ b/uv.lock
@@ -382,24 +382,10 @@ docs = [
     { name = "mkdocstrings-python" },
     { name = "pymdown-extensions" },
 ]
-document = [
-    { name = "docutils" },
-    { name = "ebooklib" },
-    { name = "mailparse" },
-    { name = "mammoth" },
-    { name = "markdownify" },
-    { name = "odfpy" },
-    { name = "openpyxl" },
-    { name = "pdfminer-six" },
-    { name = "pylatexenc" },
-    { name = "python-docx" },
-    { name = "python-pptx" },
-    { name = "striprtf" },
-]
 indic = [
     { name = "indic-nlp-library" },
 ]
-structured-document = [
+struct-doc = [
     { name = "docutils" },
     { name = "ebooklib" },
     { name = "mailparse" },
@@ -412,13 +398,6 @@ structured-document = [
     { name = "python-docx" },
     { name = "python-pptx" },
     { name = "striprtf" },
-]
-visualization = [
-    { name = "aiofiles" },
-    { name = "fastapi" },
-    { name = "msgpack" },
-    { name = "python-multipart" },
-    { name = "uvicorn" },
 ]
 viz = [
     { name = "aiofiles" },
@@ -430,52 +409,50 @@ viz = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", marker = "extra == 'visualization'", specifier = "==25.1.0" },
+    { name = "aiofiles", marker = "extra == 'viz'", specifier = "==25.1.0" },
     { name = "charset-normalizer", specifier = ">=3.4.2,<4.0" },
-    { name = "chunklet-py", extras = ["dev", "docs", "structured-document", "code", "visualization", "auto", "indic"], marker = "extra == 'dev-all'" },
-    { name = "chunklet-py", extras = ["structured-document"], marker = "extra == 'document'" },
-    { name = "chunklet-py", extras = ["structured-document", "code", "visualization", "auto", "indic"], marker = "extra == 'all'" },
-    { name = "chunklet-py", extras = ["visualization"], marker = "extra == 'viz'" },
+    { name = "chunklet-py", extras = ["dev", "docs", "struct-doc", "code", "viz", "auto", "indic"], marker = "extra == 'dev-all'" },
+    { name = "chunklet-py", extras = ["struct-doc", "code", "viz", "auto", "indic"], marker = "extra == 'all'" },
     { name = "defusedxml", marker = "extra == 'code'", specifier = ">=0.7.1,<0.8" },
-    { name = "docutils", marker = "extra == 'structured-document'", specifier = ">=0.21.2,<0.24" },
-    { name = "ebooklib", marker = "extra == 'structured-document'", specifier = ">=0.19,<0.30" },
-    { name = "fastapi", marker = "extra == 'visualization'", specifier = ">=0.116.0,<0.142" },
+    { name = "docutils", marker = "extra == 'struct-doc'", specifier = ">=0.21.2,<0.24" },
+    { name = "ebooklib", marker = "extra == 'struct-doc'", specifier = ">=0.19,<0.30" },
+    { name = "fastapi", marker = "extra == 'viz'", specifier = ">=0.116.0,<0.142" },
     { name = "indic-nlp-library", marker = "extra == 'indic'", specifier = ">=0.92,<1.0" },
     { name = "littletree", marker = "extra == 'code'", specifier = ">=0.8.7,<1.0" },
     { name = "loguru", specifier = ">=0.7.3,<1.0" },
-    { name = "mailparse", marker = "extra == 'structured-document'", specifier = ">=1.0.1,<2.0" },
-    { name = "mammoth", marker = "extra == 'structured-document'", specifier = ">=1.9.1,<2.0" },
-    { name = "markdownify", marker = "extra == 'structured-document'", specifier = ">=1.1.0,<2.0" },
+    { name = "mailparse", marker = "extra == 'struct-doc'", specifier = ">=1.0.1,<2.0" },
+    { name = "mammoth", marker = "extra == 'struct-doc'", specifier = ">=1.9.1,<2.0" },
+    { name = "markdownify", marker = "extra == 'struct-doc'", specifier = ">=1.1.0,<2.0" },
     { name = "mike", marker = "extra == 'docs'", specifier = ">=2.1.2" },
     { name = "mkdocs-api-autonav", marker = "extra == 'docs'", specifier = ">=0.4.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.6.20" },
     { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = ">=1.17.0" },
     { name = "more-itertools", specifier = ">=10.6.0,<12.0" },
     { name = "mpire", specifier = ">=2.10.2,<3.0" },
-    { name = "msgpack", marker = "extra == 'visualization'", specifier = ">=1.1.0,<2.0" },
-    { name = "odfpy", marker = "extra == 'structured-document'", specifier = ">=1.4.1,<2.0" },
-    { name = "openpyxl", marker = "extra == 'structured-document'", specifier = ">=3.1.5,<4.0" },
-    { name = "pdfminer-six", marker = "extra == 'structured-document'", specifier = ">=20250324" },
+    { name = "msgpack", marker = "extra == 'viz'", specifier = ">=1.1.0,<2.0" },
+    { name = "odfpy", marker = "extra == 'struct-doc'", specifier = ">=1.4.1,<2.0" },
+    { name = "openpyxl", marker = "extra == 'struct-doc'", specifier = ">=3.1.5,<4.0" },
+    { name = "pdfminer-six", marker = "extra == 'struct-doc'", specifier = ">=20250324" },
     { name = "py3langid", marker = "extra == 'auto'", specifier = ">=0.4.0,<0.5.0" },
     { name = "pydantic", specifier = ">=2.11.0,<3.0" },
-    { name = "pylatexenc", marker = "extra == 'structured-document'", specifier = "==2.11" },
+    { name = "pylatexenc", marker = "extra == 'struct-doc'", specifier = "==2.11" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.16.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.1" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14.1" },
-    { name = "python-docx", marker = "extra == 'structured-document'", specifier = ">=1.2.0,<2.0" },
-    { name = "python-multipart", marker = "extra == 'visualization'", specifier = ">=0.0.20,<0.33" },
-    { name = "python-pptx", marker = "extra == 'structured-document'", specifier = ">=1.0.0,<2.0" },
+    { name = "python-docx", marker = "extra == 'struct-doc'", specifier = ">=1.2.0,<2.0" },
+    { name = "python-multipart", marker = "extra == 'viz'", specifier = ">=0.0.20,<0.33" },
+    { name = "python-pptx", marker = "extra == 'struct-doc'", specifier = ">=1.0.0,<2.0" },
     { name = "regex", specifier = ">=2025.7.29" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.14" },
     { name = "sentencex", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l') or sys_platform != 'linux'", specifier = ">=1.0.0,<2.0" },
     { name = "sentencex", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'armv7l' and sys_platform == 'linux')", specifier = "<=0.6.1" },
-    { name = "striprtf", marker = "extra == 'structured-document'", specifier = ">=0.0.29,<0.34" },
+    { name = "striprtf", marker = "extra == 'struct-doc'", specifier = ">=0.0.29,<0.34" },
     { name = "typer", specifier = ">=0.19.0,<0.30" },
-    { name = "uvicorn", marker = "extra == 'visualization'", specifier = ">=0.35.0,<0.53" },
+    { name = "uvicorn", marker = "extra == 'viz'", specifier = ">=0.35.0,<0.53" },
     { name = "yasbd-lib", specifier = ">=0.16.1,<1.0" },
 ]
-provides-extras = ["indic", "auto", "structured-document", "document", "code", "visualization", "viz", "all", "dev", "docs", "dev-all"]
+provides-extras = ["indic", "auto", "struct-doc", "code", "viz", "all", "dev", "docs", "dev-all"]
 
 [[package]]
 name = "click"


### PR DESCRIPTION
## Summary

The extras were a tangle: `structured-document` and its alias `document`, plus `visualization` and its alias `viz`. This PR consolidates them down to one name per feature and drops the aliases.

## What Changed

- `structured-document` to `struct-doc` (the `document` alias for it is removed)
- `visualization` to `viz`, which now carries the visualizer dependencies directly
- `all`/`dev-all` and every error message, README, and doc updated to the new names; `uv.lock` regenerated