### PR TITLE
Polish docs language for clarity and readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,7 +258,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed critical bug where path detection logic incorrectly called `is_path_like()` on Path objects instead of strings, causing validation errors when PosixPath objects were passed. Corrected the logic to properly check `isinstance(source, Path)` first, then only call `is_path_like()` on string inputs.
 - **CLI Destination Logic:** Fixed out-of-design destination handling by removing input count restrictions, ensuring consistent JSON file output and directory handling.
 - **CLI Path Validation Bug (#6):** Resolved TypeError where len(destination) was called on a PosixPath object. Thanks to [@arnoldfranz](https://github.com/arnoldfranz) for reporting this issue.
-- **Document Chunker Batch Error Handling Bugs:** Fixed multiple bugs in `DocumentChunker._gather_all_data()` that were hidden due to missing test coverage. Issues included incorrect exception raising (`raise error` instead of `raise`), malformed logging format strings, KeyError when accessing path_section_counts for failed files, and missing early return when no files are successfully processed. These bugs were discovered and fixed while adding comprehensive test coverage for batch processing error handling.
+- **Document Chunker Batch Error Handling Bugs:** Fixed multiple bugs in `DocumentChunker._gather_all_data()` hidden due to missing test coverage: incorrect exception raising (`raise error` instead of `raise`), malformed logging format strings, KeyError when accessing path_section_counts for failed files, and missing early return when no files are successfully processed.
 
 ---
 
@@ -291,7 +291,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **CLI Bug:** Fixed a critical unpacking bug in the `split` command. The line intended to extract sentences and confidence from `splitter.split` (e.g., `sentences, confidence = splitter.split(...)`) caused either a `ValueError` (if `splitter.split` returned a number of sentences other than exactly two) or silent, incorrect unpacking (if exactly two sentences were returned, assigning the first sentence string to `sentences` and the second to `confidence`, leading to character-level iteration). The fix now correctly separates language detection and confidence retrieval from sentence splitting, resolving both issues and ensuring accurate output.
+- **CLI Bug:** Fixed a critical unpacking bug in the `split` command. The line `sentences, confidence = splitter.split(...)` caused either a `ValueError` (wrong return count) or silent incorrect unpacking (first sentence string assigned to `sentences`, second to `confidence`). The fix separates language detection from sentence splitting.
 
 ---
 
@@ -323,7 +323,7 @@ This officially boosts language support from 36+ to 50+.
     - Refactored the `SentenceSplitter` to be more modular and extensible. The management of custom splitters has been moved to a new `registry` module, which provides a centralized way to register and use custom splitter functions.
     - Introduced a new way of registering custom splitters using the `register_splitter` function and the `@registered_splitter` decorator, replacing the old dictionary-based approach. This new API is more explicit, provides better validation, and is easier to use.
 - **Improved FallbackSplitter:** Replaced the existing universal sentence splitter with a more robust, multi-stage version. The new splitter offers more accurate handling of abbreviations, numbered lists, and complex punctuation, and has a larger punctuation coverage, improving fallback support for unsupported languages.
-- **SentenceSplitter Extraction:** The core sentence splitting logic, previously embedded within `PlainTextChunker`, has been extracted and consolidated into a dedicated `SentenceSplitter` module. This significantly improves modularity, reusability, and maintainability across the library.
+- **SentenceSplitter Extraction:** The core sentence splitting logic, previously embedded within `PlainTextChunker`, has been extracted into a dedicated `SentenceSplitter` module. This improves modularity and reusability across the library.
 - **Clause Delimiters**: Added ellipsis to the list of clause delimiters for more accurate chunking.
 - **Batch Chunking Flexibility:** Modified `PlainTextChunker.batch_chunk` to accept any `Iterable` of strings for the `texts` parameter, instead of being restricted to `list`.
 - **Memory Optimization:** Refactored all batch methods in the lib to fully utilize generators, yielding chunks one at a time to reduce memory footprint, especially for large documents. That also means you dont have to wait for the chunks fully be processed before start using them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Chunklet
 
-Hey! Thanks for thinking about contributing. Bug fixes, features, docs — all welcome.
+Hey! Thanks for thinking about contributing. Bug fixes, features, docs, all welcome.
 
 ## Getting Started
 
@@ -57,7 +57,7 @@ Hey! Thanks for thinking about contributing. Bug fixes, features, docs — all w
 
 ## Pull Requests
 
-Open the PR against `main`. A PR template (`.github/PULL_REQUEST_TEMPLATE.md`) is applied automatically when you open a pull request — fill it out, keeping it scannable. Don't duplicate information GitHub already shows (files changed, commit list, branch). See the [full pull request template](.github/PULL_REQUEST_TEMPLATE.md).
+Open the PR against `main`. A PR template (`.github/PULL_REQUEST_TEMPLATE.md`) is applied automatically when you open a pull request; fill it out, keeping it scannable. Don't duplicate information GitHub already shows (files changed, commit list, branch). See the [full pull request template](.github/PULL_REQUEST_TEMPLATE.md).
 
 ## Coding Style Guidelines
 
@@ -111,7 +111,7 @@ ruff check --fix
 
 ## Submitting a Pull Request
 
-Not sure about something? Open an issue first — happy to chat before you dive in.
+Not sure about something? Open an issue first, happy to chat before you dive in.
 
 - Descriptive title
 - Summary of changes and why

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Smart chunking solves this by:
 
 ## 🤔 So What's Chunklet-py Anyway? (And Why Should You Care?)
 
-**Chunklet-py** is a developer-friendly text splitting library designed to be the most versatile chunking solution — for devs, researchers, and AI engineers. It goes way beyond basic character counting. I built this because I was tired of terrible chunking options. Chunklet-py intelligently chunks text, documents, and code into meaningful, context-aware pieces — perfect for RAG pipelines and LLM applications.
+**Chunklet-py** is a developer-friendly text splitting library for devs, researchers, and AI engineers. It goes way beyond basic character counting. I built this because I was tired of terrible chunking options. Chunklet-py intelligently chunks text, documents, and code into meaningful, context-aware pieces — perfect for RAG pipelines and LLM applications.
 
 Key features:
 
@@ -71,15 +71,15 @@ Perfect for prepping data for LLMs, building RAG systems, or powering AI search 
 
 | Feature | Why it's awesome |
 | :--- | :--- |
-| 🚀 **Blazingly Fast** | Leverages efficient parallel processing to chunk large volumes of content with remarkable speed. |
-| 🪶 **Featherlight Footprint** | Designed to be lightweight and memory-efficient, ensuring optimal performance without unnecessary overhead. |
-| 🗂️ **Rich Metadata for RAG** | Enriches chunks with valuable, context-aware metadata (source, span, document properties, code AST details) crucial for advanced RAG and LLM applications. |
-| 🔧 **Infinitely Customizable** | Offers extensive customization options, from pluggable token counters to custom sentence splitters and processors. |
-| 🌐 **Multilingual Mastery** | Supports over 60 natural languages for text and document chunking with intelligent detection and language-specific algorithms. |
-| 🧑‍💻 **Code-Aware Intelligence** | Language-agnostic code chunking that understands and preserves the structural integrity of your source code. |
-| 🎯 **Precision Chunking** | Flexible chunking with configurable limits based on sentences, tokens, sections, lines, and functions. |
-| 📄 **Document Format Mastery** | Processes a wide array of document formats including `.pdf`, `.docx`, `.epub`, `.eml`, `.pptx`, `.txt`, `.tex`, `.html`, `.hml`, `.md`, `.rst`, `.rtf`, `.odt`, `.csv`, and `.xlsx`. |
-| 💻 **Triple Interface: CLI, Library & Web** | Use it as a command-line tool, import as a library for deep integration, or launch the interactive web visualizer for real-time chunk exploration and parameter tuning. |
+| 🚀 **Blazingly Fast** | Parallel processing to chunk large volumes of content quickly. |
+| 🪶 **Featherlight Footprint** | Lightweight and memory-efficient, no unnecessary overhead. |
+| 🗂️ **Rich Metadata for RAG** | Chunks include context-aware metadata (source, span, document properties, code AST details) for RAG and LLM pipelines. |
+| 🔧 **Infinitely Customizable** | Pluggable token counters, custom sentence splitters, custom processors — mix and match. |
+| 🌐 **Multilingual Mastery** | Supports 60+ languages for text and document chunking with automatic detection and language-specific algorithms. |
+| 🧑‍💻 **Code-Aware Intelligence** | Language-agnostic code chunking that preserves the structural integrity of your source code. |
+| 🎯 **Precision Chunking** | Configurable limits based on sentences, tokens, sections, lines, and functions. |
+| 📄 **Document Format Mastery** | Handles `.pdf`, `.docx`, `.epub`, `.eml`, `.pptx`, `.txt`, `.tex`, `.html`, `.hml`, `.md`, `.rst`, `.rtf`, `.odt`, `.csv`, and `.xlsx`. |
+| 💻 **Triple Interface: CLI, Library & Web** | Command-line tool, importable library, or interactive web visualizer for real-time chunk exploration and parameter tuning. |
 
 
 And that's just the start - there's plenty more to explore!
@@ -314,7 +314,7 @@ chunklet [COMMAND] [OPTIONS*]
 
 ## How Chunklet-py Compares
 
-While there are other chunking libraries available, Chunklet-py stands out for its unique combination of versatility, performance, and ease of use. Here's a quick look at how it compares to some of the alternatives:
+While there are other chunking libraries available, Chunklet-py offers versatility, performance, and ease of use in one lightweight package. Here's a quick look at how it compares to some of the alternatives:
 
 | Library | Key Differentiator | Focus |
 | :--- | :--- | :--- |

--- a/README.md
+++ b/README.md
@@ -45,27 +45,27 @@ Dumb splitting causes problems:
 
 Smart chunking solves this by:
 
-- **Smart limits** — Respects both natural boundaries (sentences, paragraphs, sections) AND configurable limits (tokens, lines, functions)
-- **Language-aware** — Detects language automatically and applies the right rules (60+ languages supported)
-- **Context preservation** — Overlap between chunks, rich metadata (source, span, document structure)
+- **Smart limits**: respects both natural boundaries (sentences, paragraphs, sections) AND configurable limits (tokens, lines, functions)
+- **Language-aware**: detects language automatically and applies the right rules (60+ languages supported)
+- **Context preservation**: overlap between chunks, rich metadata (source, span, document structure)
 
 ## 🤔 So What's Chunklet-py Anyway? (And Why Should You Care?)
 
-**Chunklet-py** is a developer-friendly text splitting library for devs, researchers, and AI engineers. It goes way beyond basic character counting. I built this because I was tired of terrible chunking options. Chunklet-py intelligently chunks text, documents, and code into meaningful, context-aware pieces — perfect for RAG pipelines and LLM applications.
+**Chunklet-py** is a developer-friendly text splitting library for devs, researchers, and AI engineers. It goes way beyond basic character counting. I built this because I was tired of terrible chunking options. Chunklet-py intelligently chunks text, documents, and code into meaningful, context-aware pieces, perfect for RAG pipelines and LLM applications.
 
 Key features:
 
-- **Composable constraints** — Mix and match limits (sentences, tokens, sections) to get exactly the chunks you need
-- **Pluggable architecture** — Swap in custom tokenizers, sentence splitters, or processors
-- **Rich metadata** — Every chunk comes with source references, spans, and structural info
-- **Multi-format support** — PDF, DOCX, EPUB, Markdown, HTML, LaTeX, ODT, CSV, Excel, and plain text
+- **Composable constraints**: mix and match limits (sentences, tokens, sections) to get exactly the chunks you need
+- **Pluggable architecture**: swap in custom tokenizers, sentence splitters, or processors
+- **Rich metadata**: every chunk comes with source references, spans, and structural info
+- **Multi-format support**: PDF, DOCX, EPUB, Markdown, HTML, LaTeX, ODT, CSV, Excel, and plain text
 
 Available tools:
 
-- `SentenceSplitter` — Lightweight sentence tokenization
-- `DocumentChunker` — Natural language with semantic boundaries
-- `CodeChunker` — Language-aware code chunking
-- `ChunkVisualizer` — Interactive web-based exploration
+- `SentenceSplitter`: lightweight sentence tokenization
+- `DocumentChunker`: natural language with semantic boundaries
+- `CodeChunker`: language-aware code chunking
+- `ChunkVisualizer`: interactive web-based exploration
 
 Perfect for prepping data for LLMs, building RAG systems, or powering AI search - Chunklet-py gives you the precision and flexibility you need across tons of formats and languages.
 
@@ -74,7 +74,7 @@ Perfect for prepping data for LLMs, building RAG systems, or powering AI search 
 | 🚀 **Blazingly Fast** | Parallel processing to chunk large volumes of content quickly. |
 | 🪶 **Featherlight Footprint** | Lightweight and memory-efficient, no unnecessary overhead. |
 | 🗂️ **Rich Metadata for RAG** | Chunks include context-aware metadata (source, span, document properties, code AST details) for RAG and LLM pipelines. |
-| 🔧 **Infinitely Customizable** | Pluggable token counters, custom sentence splitters, custom processors — mix and match. |
+| 🔧 **Infinitely Customizable** | Pluggable token counters, custom sentence splitters, custom processors: mix and match. |
 | 🌐 **Multilingual Mastery** | Supports 60+ languages for text and document chunking with automatic detection and language-specific algorithms. |
 | 🧑‍💻 **Code-Aware Intelligence** | Language-agnostic code chunking that preserves the structural integrity of your source code. |
 | 🎯 **Precision Chunking** | Configurable limits based on sentences, tokens, sections, lines, and functions. |
@@ -94,7 +94,7 @@ And that's just the start - there's plenty more to explore!
 Ready to get Chunklet-py running? Awesome! Let's get you set up quickly and painlessly.
 
 > [!NOTE]
-> **chunklet-py (aka chunklet)** — The old `chunklet` package is no longer maintained. Use `chunklet-py` to get the latest version.
+> **chunklet-py (aka chunklet)**: the old `chunklet` package is no longer maintained. Use `chunklet-py` to get the latest version.
 
 ### The Quick & Easy Way
 
@@ -332,9 +332,9 @@ Chunklet-py is a specialized, drop-in replacement for the chunking step in any R
 
 A huge thank you to the awesome people who helped shape Chunklet-py:
 
-- [@jmbernabotto](https://github.com/jmbernabotto) — for helping mostly on the CLI part, suggesting fixes, features, and design improvements.
-- [@arnoldfranz](https://github.com/arnoldfranz) — for reporting the CLI Path Validation Bug (#6) that helped improve error handling.
-- [@AkshatSharma25](https://github.com/AkshatSharma25) — for fixing EML metadata extraction to capture all header fields.
+- [@jmbernabotto](https://github.com/jmbernabotto): helped mostly on the CLI part, suggesting fixes, features, and design improvements.
+- [@arnoldfranz](https://github.com/arnoldfranz): reported the CLI Path Validation Bug (#6) that helped improve error handling.
+- [@AkshatSharma25](https://github.com/AkshatSharma25): fixed EML metadata extraction to capture all header fields.
 
 ---
 

--- a/docs/exceptions-and-warnings.md
+++ b/docs/exceptions-and-warnings.md
@@ -12,7 +12,7 @@ The base exception. Catch this if you want to catch all the things. One ring to 
 
 ### `InvalidInputError`
 
-You passed something wrong. Wrong type, missing required field, bad file extension, etc. We tried to work with it but couldn't. This is our way of saying "that doesn't look right" — we validate inputs on the way in so you find out early.
+You passed something wrong. Wrong type, missing required field, bad file extension, etc. We tried to work with it but couldn't. This is our way of saying "that doesn't look right". We validate inputs on the way in so you find out early.
 
 **Fix:** Check the error message. It usually tells you what's up. Yes, actually read it.
 
@@ -20,7 +20,7 @@ You passed something wrong. Wrong type, missing required field, bad file extensi
 
 ### `MissingTokenCounterError` 🔢
 
-You tried to chunk by tokens but forgot to give us a `token_counter`. We can't read minds... yet. Without it, we have no idea how many tokens your text has, so we can't enforce `max_tokens`. This only applies to token-based chunking — if you're using sentences or lines, you're fine.
+You tried to chunk by tokens but forgot to give us a `token_counter`. We can't read minds... yet. Without it, we have no idea how many tokens your text has, so we can't enforce `max_tokens`. This only applies to token-based chunking; if you're using sentences or lines, you're fine.
 
 **Fix:** Pass one:
 
@@ -34,7 +34,7 @@ chunker = SomeChunker(token_counter=some_counter)
 
 ### `FileProcessingError` 📁
 
-File couldn't be read. Missing, permissions, encoding issues, corrupted — something went wrong and we gave up. This happens when we try to open a file and it fails, whether the file doesn't exist, you don't have permission, it's binary garbage, or it's just broken.
+File couldn't be read. Missing, permissions, encoding issues, corrupted: something went wrong and we gave up. This happens when we try to open a file and it fails, whether the file doesn't exist, you don't have permission, it's binary garbage, or it's just broken.
 
 **Fix:** Check if the file exists and actually opens.
 
@@ -55,7 +55,7 @@ The list of supported formats includes things like `.txt`, `.md`, `.pdf`, `.docx
 
 ### `TokenLimitError` 📏
 
-A code block is too fat for `max_tokens` and you're in `strict` mode. We refuse to split it because that would break the code. This happens in `CodeChunker` when a function or class is larger than your token limit — splitting it would result in broken, unrunnable code, so we error instead.
+A code block is too fat for `max_tokens` and you're in `strict` mode. We refuse to split it because that would break the code. This happens in `CodeChunker` when a function or class is larger than your token limit; splitting it would result in broken, unrunnable code, so we error instead.
 
 **Fix:** Bump `max_tokens` or set `strict=False` (which will split it anyway, even if it breaks).
 
@@ -63,7 +63,7 @@ A code block is too fat for `max_tokens` and you're in `strict` mode. We refuse 
 
 ### `CallbackError` 🔌
 
-Your custom callback (token_counter, splitter, processor) threw an error. Whatever you wrote in that function crashed. We wrap this so you know the error came from your code, not ours — the traceback will point you to exactly where things went sideways.
+Your custom callback (token_counter, splitter, processor) threw an error. Whatever you wrote in that function crashed. We wrap this so you know the error came from your code, not ours; the traceback will point you to exactly where things went sideways.
 
 **Fix:** Debug your callback. The stack trace has the answers.
 
@@ -77,7 +77,7 @@ Your custom callback (token_counter, splitter, processor) threw an error. Whatev
 The language is set to `auto`. Consider setting `lang` explicitly.
 ```
 
-**What it means:** We don't know what language your text is. Auto-detect works, but explicit is faster and more reliable, especially with short texts. Language detection is a guess — short texts have less signal, so the guess is less confident.
+**What it means:** We don't know what language your text is. Auto-detect works, but explicit is faster and more reliable, especially with short texts. Language detection is a guess; short texts have less signal, so the guess is less confident.
 
 **Fix:** Pass `lang='en'` (or whatever) if you know it.
 
@@ -89,7 +89,7 @@ The language is set to `auto`. Consider setting `lang` explicitly.
 Using universal rule-based splitter. Language not supported or detected with low confidence.
 ```
 
-**What it means:** No specialized splitter for your language exists in yasbd or the other backends. We're using the generic regex fallback instead. Some languages have complex punctuation rules that the specialized splitters handle — the fallback is a one-size-fits-all that works okay but isn't great for anything.
+**What it means:** No specialized splitter for your language exists in yasbd or the other backends. We're using the generic regex fallback instead. Some languages have complex punctuation rules that the specialized splitters handle; the fallback is a one-size-fits-all that works okay but isn't great for anything.
 
 **Fix:** The fallback is a one-size-fits-all that's decent for most cases.
 
@@ -101,7 +101,7 @@ Using universal rule-based splitter. Language not supported or detected with low
 Offset {} >= total sentences {}. Returning empty list.
 ```
 
-**What it means:** Your offset is bigger than the text. There's nothing left to split so we return nothing. This is just informing you — it's not an error, you just asked for more sentences than exist.
+**What it means:** Your offset is bigger than the text. There's nothing left to split so we return nothing. This is just informing you; it's not an error, you just asked for more sentences than exist.
 
 **Fix:** Use a smaller offset.
 
@@ -113,7 +113,7 @@ Offset {} >= total sentences {}. Returning empty list.
 Skipping failed task. Reason: {error}
 ```
 
-**What it means:** One file in your batch choked and you set `on_errors='skip'`. We logged the error and kept going. This is intentional — you told us to continue on error, so we do. Check the logs to see what actually failed.
+**What it means:** One file in your batch choked and you set `on_errors='skip'`. We logged the error and kept going. This is intentional; you told us to continue on error, so we do. Check the logs to see what actually failed.
 
 **Fix:** Check the reason. Fix the file or change `on_errors`.
 
@@ -125,7 +125,7 @@ Skipping failed task. Reason: {error}
 Skipping document {path} due to validation failure. Reason: {reason}
 ```
 
-**What it means:** File failed validation. Bad extension, corrupted, or some other issue — we couldn't process it. This happens before we even try to extract text — the file just doesn't look right.
+**What it means:** File failed validation. Bad extension, corrupted, or some other issue: we couldn't process it. This happens before we even try to extract text; the file just doesn't look right.
 
 **Fix:** Check the reason.
 
@@ -149,7 +149,7 @@ No valid files found after validation. Returning empty generator.
 Splitting oversized block ({token_count} tokens) into sub-chunks
 ```
 
-**What it means:** A code block exceeded `max_tokens`. In non-strict mode, we split it anyway to avoid throwing an error. This is us being helpful — we could have errored, but instead we broke it into smaller chunks even though they're not valid code anymore.
+**What it means:** A code block exceeded `max_tokens`. In non-strict mode, we split it anyway to avoid throwing an error. This is us being helpful: we could have errored, but instead we broke it into smaller chunks even though they're not valid code anymore.
 
 **Fix:** Set `strict=True` if you want it to error instead.
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -19,7 +19,7 @@ chunklet visualize --help
 
 ## The `split` Command: Precision Sentence Segmentation ✂️
 
-Need to break down text into individual sentences with surgical precision? The `split` command is your go-to! It leverages `chunklet`'s powerful [`SentenceSplitter`](programmatic/sentence_splitter.md) to give you clean, segmented sentences.
+Need to break down text into individual sentences with surgical precision? The `split` command is your go-to! It uses `chunklet`'s [`SentenceSplitter`](programmatic/sentence_splitter.md) to give you clean, segmented sentences.
 
 ### Quick Facts for `split`
 
@@ -39,7 +39,7 @@ Need to break down text into individual sentences with surgical precision? The `
 
 #### Scenario 1: Splitting Text Directly (and Multilingually!)
 
-Segment a direct text input containing multiple languages into individual sentences, leveraging automatic language detection.
+Segment a direct text input containing multiple languages into individual sentences, using automatic language detection.
 
 ```bash
 chunklet split "This is the first sentence. Here is the second sentence, in French. C'est la vie! ¿Cómo estás?" --lang auto
@@ -57,7 +57,7 @@ chunklet split --source my_novel_chapter.txt --destination sentences.txt --lang 
 
 ## The `chunk` Command: Your Intelligent Chunking Workhorse!
 
-The `chunk` command is where the real magic happens! It's your versatile tool for breaking down text, documents, and even code into RAG-ready chunks. The "flavor" of chunking (plain text, document, or code) is determined by the flags you provide.
+The `chunk` command is where the chunking happens! It's your versatile tool for breaking down text, documents, and even code into RAG-ready chunks. The "flavor" of chunking (plain text, document, or code) is determined by the flags you provide.
 
 ### Key Flags for `chunk` (The Essentials!)
 
@@ -81,8 +81,8 @@ The `chunk` command is where the real magic happens! It's your versatile tool fo
 
 This is your bread-and-butter chunking for everyday text and diverse document types.
 
-*   **Default Behavior:** If neither `--doc` nor `--code` is specified, `chunklet` uses the [DocumentChunker](programmatic/document_chunker.md) for direct text input. The `DocumentChunker` is designed to transform unruly text into perfectly sized, context-aware chunks.
-*   **Document Power-Up:** Activate the [DocumentChunker](programmatic/document_chunker.md) with the `--doc` flag to process `.pdf`, `.docx`, `.odt`, `.epub`, `.eml`, `.pptx`, `.txt`, `.tex`, `.html`, `.hml`, `.md`, `.rst`, `.csv`, `.xlsx` and `.rtf` files! It intelligently extracts text and then applies the same robust chunking logic.
+*   **Default Behavior:** If neither `--doc` nor `--code` is specified, `chunklet` uses the [DocumentChunker](programmatic/document_chunker.md) for direct text input. The `DocumentChunker` transforms unruly text into context-aware chunks.
+*   **Document Power-Up:** Activate the [DocumentChunker](programmatic/document_chunker.md) with the `--doc` flag to process `.pdf`, `.docx`, `.odt`, `.epub`, `.eml`, `.pptx`, `.txt`, `.tex`, `.html`, `.hml`, `.md`, `.rst`, `.csv`, `.xlsx` and `.rtf` files! It extracts text and then applies the same chunking logic.
 
 #### Key Flags for Document Power-Up
 
@@ -250,7 +250,7 @@ chunklet chunk --doc \
 
 #### Scenario 3: Processing Multiple Specific Files with Advanced Hooks
 
-Process a selection of individual files, explicitly listing each one, and apply advanced chunking parameters. This demonstrates how to handle a non-directory batch of files, ensuring each is processed with metadata and error handling.
+Process a selection of individual files, explicitly listing each one, and apply advanced chunking parameters.
 
 ```bash
 chunklet chunk --doc \
@@ -265,7 +265,7 @@ chunklet chunk --doc \
 
 #### Scenario 4: Custom Token Counting with an External Script
 
-Align `chunklet`'s chunk sizes perfectly with your LLM's token limits using *any* external tokenizer you can imagine! Optionally set a timeout:
+Align `chunklet`'s chunk sizes with your LLM's token limits using any external tokenizer! Optionally set a timeout:
 
 ```bash
 chunklet chunk --text "Your text here" \
@@ -297,13 +297,13 @@ chunklet chunk --doc \
 
 Want to know *exactly* what kind of rich context `chunklet` attaches to your chunks? From source paths and character spans to document-specific properties and code AST details.
 
-👉 Head over to the [Metadata in Chunklet-py guide](../getting-started/metadata.md) to unlock all its secrets!
+👉 Head over to the [Metadata in Chunklet-py guide](../getting-started/metadata.md) to see everything it tracks!
 
 ---
 
 ## The `visualize` Command: Your Interactive Chunk Playground! 🎮
 
-Ready to see your chunking in action with a beautiful web interface? The `visualize` command launches Chunklet's interactive web visualizer - perfect for experimenting with parameters, seeing real-time results, and fine-tuning your chunking strategies!
+Ready to see your chunking in action with a web interface? The `visualize` command launches Chunklet's interactive web visualizer - perfect for experimenting with parameters, seeing real-time results, and fine-tuning your chunking strategies!
 
 !!! tip "Want programmatic control?"
     For code-based usage and detailed technical information, check out the [Text Chunk Visualizer documentation](programmatic/visualizer.md).
@@ -358,7 +358,7 @@ See the [Custom Tokenizers](../how-to/custom-tokenizer.md) guide for how to crea
 The visualizer will show you the URL to access it in your browser. Press `Ctrl+C` to stop the server when you're done!
 
 !!! info "REST API for Headless Automation! 🤖"
-    When running in headless mode, you can use the visualizer's REST API to programmatically upload files, chunk content, and retrieve results without any web interface! Perfect for automation scripts, CI/CD pipelines, or integrating chunking into your applications.
+    When running in headless mode, you can use the visualizer's REST API to programmatically upload files, chunk content, and retrieve results without a browser. Great for automation scripts, CI/CD pipelines, or integrating chunking into your applications.
 
     See the [Headless/REST API Usage](programmatic/visualizer.md#headlessrest-api-usage) section for complete examples of programmatic file processing.
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -1,6 +1,6 @@
 # Chunklet CLI
 
-Meet `chunklet`, your CLI companion for text processing! From sentence splitting to smart chunking to interactive visualization — it's all here.
+Meet `chunklet`, your CLI companion for text processing! From sentence splitting to smart chunking to interactive visualization: it's all here.
 
 !!! info "`chunklet` vs `chunklet-py`"
     The CLI command is `chunklet` (kept for backward compatibility), while the Python package is named `chunklet-py` to avoid naming conflicts with other packages.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Ready to get Chunklet-py up and running? Fantastic! This guide will walk you through the installation process, making it as smooth as possible.
+Ready to install Chunklet-py? Here's how.
 
 !!! info "Requirements"
     Chunklet-py requires **Python 3.11 or newer**. We recommend using Python 3.12+ for the best experience.
@@ -33,7 +33,7 @@ And that's all there is to it! You're now ready to start using Chunklet-py.
 
 ## Optional Dependencies
 
-Chunklet-py offers optional dependencies to unlock additional functionalities, such as document processing or code chunking. You can install these extras using the following syntax:
+Chunklet-py offers optional extras for document processing, code chunking, and more. Install them like this:
 
 *   **Structured Documents:** For handling `.pdf`, `.docx`, `.epub`, `.eml`, `.pptx`, and other document formats:
     ```bash
@@ -55,14 +55,14 @@ Chunklet-py offers optional dependencies to unlock additional functionalities, s
     ```bash
     pip install "chunklet-py[viz]"
     ```
-*   **All Extras:** To install all optional dependencies:
+*   **All Extras:** Everything:
     ```bash
     pip install "chunklet-py[all]"
     ```
 
 ## The Alternative Way
 
-For those who prefer to build from source, you can clone the repository and install it manually. This method allows for direct modification of the source code and installation of all optional features:
+For those who prefer to build from source, clone the repository and install it manually. This gives you direct access to the source code and all optional features:
 
 ```bash
 git clone https://github.com/speedyk-005/chunklet-py.git
@@ -74,7 +74,7 @@ But why would you want to do that? The pip way is so much easier.
 
 ## Contributing to Chunklet-py
 
-Interested in helping make Chunklet-py even better? That's fantastic! Before you dive in, please take a moment to review our [**Contributing Guide**](https://github.com/speedyk-005/chunklet-py/blob/main/CONTRIBUTING.md). Here's how you can set up your development environment:
+Interested in helping make Chunklet-py even better? Before you dive in, please take a moment to review our [**Contributing Guide**](https://github.com/speedyk-005/chunklet-py/blob/main/CONTRIBUTING.md). Here's how you can set up your development environment:
 
 ```bash
 git clone https://github.com/speedyk-005/chunklet-py.git
@@ -87,6 +87,6 @@ pip install -e ".[docs]"
 pip install -e ".[dev-all]"
 ```
 
-These commands install Chunklet-py in "editable" mode, ensuring that any changes you make to the source code are immediately reflected. The `[dev]`, `[docs]`, and `[dev-all]` options include the necessary dependencies for specific development tasks.
+These commands install Chunklet-py in editable mode, so source changes take effect immediately. The `[dev]`, `[docs]`, and `[dev-all]` options include dependencies for specific development tasks.
 
 Now, go forth and code! And remember, good developers always write tests. (Even in a Python project, we appreciate all forms of excellent code examples!)

--- a/docs/getting-started/metadata.md
+++ b/docs/getting-started/metadata.md
@@ -1,8 +1,8 @@
 # Metadata in Chunklet-py: Your Chunk's Story 📖
 
-Ever wondered where your chunks come from and what makes them tick? 🤔 Chunklet-py's metadata system tells you exactly that. Each chunk comes with contextual information about its origin, location, and characteristics. Think of metadata as your chunk's detailed biography - the who, what, when, and where of your text.
+Ever wondered where your chunks come from and what makes them tick? 🤔 Chunklet-py's metadata system tells the whole story! Each chunk comes with contextual information about its origin, location, and characteristics. Think of metadata as your chunk's detailed biography - the who, what, when, and where of your text.
 
-Every chunk is wrapped in a handy [`DotDict`][chunklet.common.dotdict.DotDict] object with a `metadata` attribute. This dictionary stores all the chunk metadata. Access it with dot notation (`chunk.metadata`) or dictionary-style (`chunk["metadata"]`).
+Every chunk is wrapped in a handy [`DotDict`][chunklet.common.dotdict.DotDict] object with a `metadata` attribute. This metadata dictionary is your treasure trove of chunk insights. Access it easily with dot notation (`chunk.metadata`) or dictionary-style (`chunk["metadata"]`) - your choice!
 
 ## Common Metadata: The Essentials 📋 {#common-metadata}
 

--- a/docs/getting-started/metadata.md
+++ b/docs/getting-started/metadata.md
@@ -1,16 +1,16 @@
 # Metadata in Chunklet-py: Your Chunk's Story 📖
 
-Ever wondered where your chunks come from and what makes them tick? 🤔 Chunklet-py's metadata system tells the whole story! Each chunk comes with rich contextual information about its origin, location, and characteristics. Think of metadata as your chunk's detailed biography - the who, what, when, and where of your text.
+Ever wondered where your chunks come from and what makes them tick? 🤔 Chunklet-py's metadata system tells you exactly that. Each chunk comes with contextual information about its origin, location, and characteristics. Think of metadata as your chunk's detailed biography - the who, what, when, and where of your text.
 
-Every chunk is wrapped in a handy [`DotDict`][chunklet.common.dotdict.DotDict] object with a `metadata` attribute. This metadata dictionary is your treasure trove of chunk insights. Access it easily with dot notation (`chunk.metadata`) or dictionary-style (`chunk["metadata"]`) - your choice!
+Every chunk is wrapped in a handy [`DotDict`][chunklet.common.dotdict.DotDict] object with a `metadata` attribute. This dictionary stores all the chunk metadata. Access it with dot notation (`chunk.metadata`) or dictionary-style (`chunk["metadata"]`).
 
 ## Common Metadata: The Essentials 📋 {#common-metadata}
 
-No matter which chunker you use, every chunk includes these fundamental metadata fields. Think of them as your chunk's basic information - the essentials you need to know.
+No matter which chunker you use, every chunk includes these metadata fields. Think of them as your chunk's basic information.
 
 *   **`chunk_num`** (int): Your chunk's sequential ID number within each source - perfect for keeping things organized
 *   **`span`** (tuple[int, int]): Character position coordinates showing exactly where this chunk sits in the original text
-*   **`source`** (str): Where did this chunk come from? (The origin story!)
+*   **`source`** (str): Where did this chunk come from?
      *   **File processing**: Absolute path to the file (for [DocumentChunker](programmatic/document_chunker.md) or [CodeChunker](programmatic/code_chunker.md))
      *   **CLI text input**: `"stdin"` (because it came from standard input)
      *   **Document chunker Text input**: Only included if you provide it via `base_metadata` parameter
@@ -22,11 +22,11 @@ The `DocumentChunker` provides comprehensive metadata for both text and file inp
 
 ### Text Input
 
-Keeps things straightforward and clean. Your chunks include the essential [Common Metadata](#common-metadata) fields (`chunk_num` and `span`). No frills, just the basics - perfect when you want clean, minimal metadata without any extra baggage. Additional metadata can be provided via the `base_metadata` parameter.
+Keeps things straightforward and clean. Your chunks include the essential [Common Metadata](#common-metadata) fields (`chunk_num` and `span`). No frills, just the basics. Additional metadata can be provided via the `base_metadata` parameter.
 
 ### File Input
 
-Need more context? File input's got you covered! Provides comprehensive metadata beyond the basics - revealing detailed insights about each file's properties and history:
+Need more context? File input's got you covered! Provides comprehensive document metadata - including detailed insights about each file's properties and history:
 
 **Universal Fields (for multi-section docs):**
 
@@ -47,7 +47,7 @@ Need more context? File input's got you covered! Provides comprehensive metadata
 
 ## CodeChunker Metadata: Code Intelligence 💻 {#codechunker-metadata}
 
-The `CodeChunker` provides code-specific insights beyond basic metadata. It helps you understand the structural context of each chunk - perfect for tracking where your code elements originated! 🔍
+The `CodeChunker` provides code-specific metadata beyond the basics. It helps you understand the structural context of each chunk - perfect for tracking where your code elements originated! 🔍
 
 **Code-Specific Information:**
 
@@ -59,17 +59,17 @@ Automatically included in every [`DotDict`][chunklet.common.dotdict.DotDict] obj
 
 ## CLI Metadata Output: Command Line Insights 🖥️
 
-The `chunklet` [CLI](../getting-started/cli.md) adapts metadata output based on your input type and flags. Think of it as your CLI's helpful companion that provides just the right context!
+The `chunklet` [CLI](../getting-started/cli.md) adapts metadata output based on your input type and flags.
 
 **Metadata Control:** The `--metadata` flag gives you control over what gets included.
 
 *   **With `--metadata`**: Your chunks come with their full context - metadata appears alongside content, either printed to stdout or saved in `.json` files with `--destination`
-*   **Without `--metadata`**: Just the chunk content - clean and simple when you want to focus purely on the text
+*   **Without `--metadata`**: Just the chunk content - clean and simple
 
 **Metadata by Input Type:**
 
 *   **Direct Text Input** (`chunklet chunk "Your text..."`): Uses `DocumentChunker` with essential [Common Metadata](#common-metadata) fields (`chunk_num`, `span`, ...) and `source` set to `"stdin"`
-*   **Document Processing** (`chunklet chunk --doc --source document.pdf`): `DocumentChunker` provides rich document metadata including [Common Metadata](#common-metadata) plus file-specific details (PDF titles, EPUB creators, DOCX authors, ODT creators) as detailed in [DocumentChunker Metadata](#documentchunker-metadata)
+*   **Document Processing** (`chunklet chunk --doc --source document.pdf`): `DocumentChunker` provides document metadata including [Common Metadata](#common-metadata) plus file-specific details (PDF titles, EPUB creators, DOCX authors, ODT creators) as detailed in [DocumentChunker Metadata](#documentchunker-metadata)
 *   **Code Processing** (`chunklet chunk --code --source code.py`): `CodeChunker` includes structural information with [Common Metadata](#common-metadata) and code-specific fields like `tree`, `start_line`, `end_line` as described in [CodeChunker Metadata](#codechunker-metadata)
 
-The CLI automatically provides the most relevant metadata for your use case - making chunk analysis both powerful and intuitive. Smart and simple! 🎯
+The CLI automatically picks the most relevant metadata for your use case. Smart and simple! 🎯

--- a/docs/getting-started/programmatic/code_chunker.md
+++ b/docs/getting-started/programmatic/code_chunker.md
@@ -16,19 +16,19 @@ This installs all the code processing dependencies needed for language-agnostic 
 
 Got a massive codebase that's hard to navigate? The `CodeChunker` transforms tangled functions and classes into clean, understandable chunks that actually make sense.
 
-It uses pattern-based line-by-line processing to identify code structures — no heavy parsers needed. Lightweight yet surprisingly accurate across 30+ languages.
+It uses pattern-based line-by-line processing to identify code structures, no heavy parsers needed. Lightweight yet surprisingly accurate across 30+ languages.
 
 ### Code Chunker Superpowers! ⚡
 
 The `CodeChunker` comes loaded with features for your coding adventures:
 
--  **Multi-Language Support:** Works with 30+ languages out of the box — Python, JavaScript, Java, C++, Go, Rust, PHP, and more! One library to rule them all! 🌍
--  **Convention-Aware:** Assumes your code plays by the rules — no full language parsers needed for surprisingly accurate results! 🎯
+-  **Multi-Language Support:** Works with 30+ languages out of the box: Python, JavaScript, Java, C++, Go, Rust, PHP, and more! One library to rule them all! 🌍
+-  **Convention-Aware:** Assumes your code plays by the rules: no full language parsers needed for surprisingly accurate results! 🎯
 -  **Flexible Composable Constraints:** Full control over code segmentation! Mix and match limits based on tokens, lines, or functions for chunks that fit your needs. 🎛️
 -  **Customizable Token Counting:** Plug in your own token counter for alignment with different LLMs. Because one size definitely doesn't fit all models! 🤖
--  **Annotation-Aware:** Keeps comments and docstrings intact — your code's story stays complete! 📝
+-  **Annotation-Aware:** Keeps comments and docstrings intact, so your code's story stays complete! 📝
 -  **Strict Mode Control:** By default keeps functions and classes together even if large. Set `strict=False` for more flexibility. No more orphaned code! 🛡️
--  **Namespace Hierarchy Tracking:** Builds a tree of your code's structure — functions, classes, namespaces — all tracked for accurate metadata 🌳
+-  **Namespace Hierarchy Tracking:** Builds a tree of your code's structure: functions, classes, namespaces, all tracked for accurate metadata 🌳
 -  **Memory-Conscious Operation:** Handles massive codebases efficiently by yielding chunks one at a time. Your RAM will thank you later! 💾
 -  **Bulk Processing Powerhouse:** Got a mountain of code files to conquer? No problem! This powerhouse processes multiple files in parallel. 📚⚡
 

--- a/docs/getting-started/programmatic/code_chunker.md
+++ b/docs/getting-started/programmatic/code_chunker.md
@@ -20,17 +20,17 @@ It uses pattern-based line-by-line processing to identify code structures — no
 
 ### Code Chunker Superpowers! ⚡
 
-The `CodeChunker` comes packed with smart features for your coding adventures:
+The `CodeChunker` comes loaded with features for your coding adventures:
 
 -  **Multi-Language Support:** Works with 30+ languages out of the box — Python, JavaScript, Java, C++, Go, Rust, PHP, and more! One library to rule them all! 🌍
 -  **Convention-Aware:** Assumes your code plays by the rules — no full language parsers needed for surprisingly accurate results! 🎯
--  **Flexible Composable Constraints:** Ultimate control over code segmentation! Mix and match limits based on tokens, lines, or functions for perfect chunks. 🎛️
--  **Customizable Token Counting:** Plug in your own token counter for perfect alignment with different LLMs. Because one size definitely doesn't fit all models! 🤖
+-  **Flexible Composable Constraints:** Full control over code segmentation! Mix and match limits based on tokens, lines, or functions for chunks that fit your needs. 🎛️
+-  **Customizable Token Counting:** Plug in your own token counter for alignment with different LLMs. Because one size definitely doesn't fit all models! 🤖
 -  **Annotation-Aware:** Keeps comments and docstrings intact — your code's story stays complete! 📝
 -  **Strict Mode Control:** By default keeps functions and classes together even if large. Set `strict=False` for more flexibility. No more orphaned code! 🛡️
 -  **Namespace Hierarchy Tracking:** Builds a tree of your code's structure — functions, classes, namespaces — all tracked for accurate metadata 🌳
 -  **Memory-Conscious Operation:** Handles massive codebases efficiently by yielding chunks one at a time. Your RAM will thank you later! 💾
--  **Bulk Processing Powerhouse:** Got a mountain of code files to conquer? No problem! This powerhouse efficiently processes multiple files in parallel. 📚⚡
+-  **Bulk Processing Powerhouse:** Got a mountain of code files to conquer? No problem! This powerhouse processes multiple files in parallel. 📚⚡
 
 ### Code Constraints: Your Chunking Control Panel! 🎛️
 
@@ -401,7 +401,7 @@ for i, chunk in enumerate(chunks):
     You can also provide the `token_counter` directly to any chunking method (e.g., `chunker.chunk_text(..., token_counter=my_tokenizer_function)`). If a `token_counter` is provided in both the constructor and the chunking method, the one in the method call will be used.
 
 ### Combining Multiple Constraints: Mix and Match Magic! 🎭
-The real power of `CodeChunker` comes from combining multiple constraints. This allows for highly specific and granular control over how your code is chunked. Here are a few examples of how you can combine different constraints.
+The real power of `CodeChunker` comes from combining multiple constraints. Here are a few ways to layer them:
 
 ```py linenums="1" hl_lines="1-3"
 chunker.max_lines = 8
@@ -413,7 +413,7 @@ chunk = chunker.chunk_text(PYTHON_CODE)
 
 ## Batch Run: Processing Multiple Code Inputs Like a Pro! 📚
 
-While `chunk_text`/`chunk_file` is perfect for single code inputs, `chunk_texts` and `chunk_files` are your power players for processing multiple code inputs in parallel. They use memory-friendly generators so you can handle massive codebases with ease.
+While `chunk_text`/`chunk_file` handles single code inputs, `chunk_texts` and `chunk_files` are for processing multiple code inputs in parallel. They use memory-friendly generators so you can work through large codebases without loading everything at once.
 
 - `chunk_texts()` - process multiple raw code strings
 - `chunk_files()` - process multiple file paths
@@ -803,7 +803,7 @@ for i, code_chunks in enumerate(chunk_groups):
     While powerful, `CodeChunker` isn't magic! It assumes your code is reasonably well-behaved (syntactically conventional). Highly obfuscated, minified, or macro-generated sources might give it a headache. Also, nested docstrings or comment blocks can be a bit tricky for it to handle perfectly.
 
 ## Inspiration: The Code Behind the Magic! ✨
-The `CodeChunker` draws inspiration from various projects and concepts in the field of code analysis and segmentation. These influences have shaped its design principles and capabilities:
+The `CodeChunker` draws inspiration from a few projects in code analysis and segmentation:
 
 -  [code_chunker](https://github.com/camel-ai/camel/blob/master/camel/utils/chunker/code_chunker.py) by Camel AI
 -  [code_chunker](https://github.com/JimAiMoment/code-chunker) by JimAiMoment

--- a/docs/getting-started/programmatic/document_chunker.md
+++ b/docs/getting-started/programmatic/document_chunker.md
@@ -24,7 +24,7 @@ This installs all the document processing dependencies needed to handle PDFs, DO
 
 Got a wall of text that's overwhelming? The `DocumentChunker` transforms unruly paragraphs into sized, context-aware chunks. Perfect for RAG systems and document analysis.
 
-It preserves meaning and flow — no confusing puzzle pieces.
+It preserves meaning and flow, no confusing puzzle pieces.
 
 ### Where `DocumentChunker` Really Shines
 
@@ -51,13 +51,13 @@ The `DocumentChunker` comes loaded with features that make it your go-to text wr
 | :------------------- | :---------------- | :---------- |
 | `max_sentences`      | `int >= 1`        | Sentence power mode! Tell us how many sentences per chunk, and we'll group them thoughtfully so your ideas flow like a well-written story. |
 | `max_tokens`         | `int >= 12`       | Token budget watcher! We'll carefully pack sentences into chunks while respecting your token limits. If a sentence gets too chatty, we'll politely split it at clause boundaries. 🤐 |
-| `max_section_breaks` | `int >= 1`        | Structure superhero! Limits section breaks per chunk — headings (`##`), horizontal rules (`---`, `***`, `___`), and `<details>` tags. Your document structure stays intact! |
+| `max_section_breaks` | `int >= 1`        | Structure superhero! Limits section breaks per chunk: headings (`##`), horizontal rules (`---`, `***`, `___`), and `<details>` tags. Your document structure stays intact! |
 | `overlap_percent`    | `int 0-75`        | Repeat a bit of the previous chunk's tail for continuity. Defaults to 20. |
 | `offset`             | `int >= 0`        | Skip the first N sentences before chunking. Defaults to 0. |
 | `lang`               | `str`             | Language code (`'en'`, `'fr'`, ...) or `'auto'`. Required. |
 
 !!! note "Auto language detection requires the `[auto]` extra"
-    When you use `lang="auto"`, the chunker needs `py3langid` to detect the language of your text. This is not installed by default — install it with:
+    When you use `lang="auto"`, the chunker needs `py3langid` to detect the language of your text. This is not installed by default; install it with:
 
     ```bash
     pip install 'chunklet-py[auto]'
@@ -467,7 +467,7 @@ for i, doc_chunks in enumerate(chunk_groups):
 
 Want to handle exotic file formats that `DocumentChunker` doesn't know about? Create your own custom processors! This lets you add specialized processing for any file type and prioritize your custom processors over the built-in ones.
 
-Custom processors live in a [`CustomProcessorRegistry`](../../reference/chunklet/document_chunker/registry.md) instance that **you create and own**. Create a registry, register your processors on it, and pass it to a `DocumentChunker` via the `processor_registry` parameter. This gives you full control over scope — no more global side effects.
+Custom processors live in a [`CustomProcessorRegistry`](../../reference/chunklet/document_chunker/registry.md) instance that **you create and own**. Create a registry, register your processors on it, and pass it to a `DocumentChunker` via the `processor_registry` parameter. This gives you full control over scope, no more global side effects.
 
 To use a custom processor, you leverage the [`@registry.register`](../../reference/chunklet/document_chunker/registry.md) decorator. This decorator allows you to register your function for one or more file extensions directly. Your custom processor function must accept a single `file_path` parameter (str) and return a `tuple[str | list[str], dict]` containing extracted text (or list of texts for multi-section documents) and a metadata dictionary.
 

--- a/docs/getting-started/programmatic/document_chunker.md
+++ b/docs/getting-started/programmatic/document_chunker.md
@@ -22,22 +22,22 @@ This installs all the document processing dependencies needed to handle PDFs, DO
 
 ## Taming Your Text and Documents with Precision
 
-Got a wall of text that's overwhelming? The `DocumentChunker` transforms unruly paragraphs into perfectly sized, context-aware chunks. Perfect for RAG systems and document analysis.
+Got a wall of text that's overwhelming? The `DocumentChunker` transforms unruly paragraphs into sized, context-aware chunks. Perfect for RAG systems and document analysis.
 
 It preserves meaning and flow — no confusing puzzle pieces.
 
 ### Where `DocumentChunker` Really Shines
 
-The `DocumentChunker` comes packed with smart features that make it your go-to text wrangling sidekick:
+The `DocumentChunker` comes loaded with features that make it your go-to text wrangling sidekick:
 
--  **Flexible Composable Constraints:** Ultimate control over your chunks! Mix and match limits based on sentences, tokens, or section breaks (headings, horizontal rules, `<details>` tags). Craft exactly the chunk size you need with precision control! 🎯
--  **Intelligent Overlap:** Adds smart overlaps between chunks so your text flows smoothly. No more jarring transitions that leave readers scratching their heads!
--  **Extensive Multilingual Support:** Speaks over 60 languages fluently, thanks to our trusty sentence splitter. Global domination through better text chunking! 🌍
--  **Customizable Token Counting:** Plug in your own token counter for perfect alignment with different LLMs. Because one size definitely doesn't fit all models!
+-  **Flexible Composable Constraints:** Full control over your chunks! Mix and match limits based on sentences, tokens, or section breaks (headings, horizontal rules, `<details>` tags). Craft exactly the chunk size you need. 🎯
+-  **Overlap:** Adds overlap between chunks so your text flows smoothly. No more jarring transitions that leave readers scratching their heads!
+-  **Multilingual Support:** Speaks over 60 languages fluently, thanks to our trusty sentence splitter. Global domination through better text chunking! 🌍
+-  **Customizable Token Counting:** Plug in your own token counter for alignment with different LLMs. Because one size definitely doesn't fit all models!
 -  **Memory-Conscious Operation:** Handles massive documents efficiently by yielding chunks one at a time. Your RAM will thank you later! 💾
 -  **Multi-Format Maestro:** From corporate DOCX boardrooms to academic PDF libraries, this chunker speaks every file language fluently! Handles `.pdf`, `.docx`, `.epub`, `.eml`, `.pptx`, `.txt`, `.tex`, `.html`, `.hml`, `.md`, `.rst`, `.rtf`, `.odt`, `.csv`, and `.xlsx` files like a pro. 🌍
--  **Metadata Magician:** Not just text - it automatically enriches your chunks with valuable metadata. Your chunks come with bonus context! 📊
--  **Bulk Processing Powerhouse:** Got a mountain of documents to conquer? No problem! This powerhouse efficiently processes multiple documents in parallel. 📚⚡
+-  **Metadata Magician:** Not just text - it automatically enriches your chunks with metadata. Your chunks come with bonus context! 📊
+-  **Bulk Processing Powerhouse:** Got a mountain of documents to conquer? No problem! This powerhouse processes multiple documents in parallel. 📚⚡
 -  **Pluggable Processor Power:** Have a mysterious file format that's one-of-a-kind? Plug in your own custom processors - `DocumentChunker` is ready for any challenge you throw at it! 🔌🛠️
 
 !!! note "No Scanned PDF Support"
@@ -340,7 +340,7 @@ chunks = chunker.chunk_file(path=file_path)
 
 ## Batch: Chunk Multiple Items! 📚
 
-While `chunk_text` is perfect for single texts and `chunk_file` for single files, `chunk_texts` and `chunk_files` are your power players for processing multiple texts or files in parallel. They use memory-friendly generators so you can handle massive collections with ease.
+While `chunk_text` handles single texts and `chunk_file` single files, `chunk_texts` and `chunk_files` are for processing multiple texts or files in parallel. They use memory-friendly generators so you can work through large collections without loading everything at once.
 
 - `chunk_texts()` - process multiple raw text strings
 - `chunk_files()` - process multiple file paths

--- a/docs/getting-started/programmatic/index.md
+++ b/docs/getting-started/programmatic/index.md
@@ -28,7 +28,7 @@ Welcome to the programmatic interface! This is where you integrate Chunklet-py's
 
     Chunks source code while preserving logical structure and maintaining code semantics across functions, classes, and modules.
 
-    Language-agnostic and lightweight — great for code understanding, generation, analysis, documentation, and AI model training.
+    Language-agnostic and lightweight, great for code understanding, generation, analysis, documentation, and AI model training.
 
     [:octicons-arrow-right-24: Learn More](code_chunker.md)
 

--- a/docs/getting-started/programmatic/index.md
+++ b/docs/getting-started/programmatic/index.md
@@ -1,4 +1,4 @@
-Welcome to the programmatic interface! This is where you integrate Chunklet-py's chunking capabilities directly into your Python apps. Building RAG pipelines, data processing workflows, or custom AI solutions? We've got you covered.
+Welcome to the programmatic interface! This is where you integrate Chunklet-py's chunking capabilities directly into your Python apps.
 
 <div class="grid cards" markdown>
 
@@ -6,9 +6,9 @@ Welcome to the programmatic interface! This is where you integrate Chunklet-py's
 
     ---
 
-    Precisely splits text into semantically meaningful sentences across 60+ languages with intelligent detection and complex structure handling.
+    Splits text into sentences across 60+ languages with automatic language detection and complex structure handling.
 
-    Essential for preparing clean text data for NLP tasks, LLMs, and any application that needs accurate sentence boundaries.
+    Great for preparing clean text data for NLP tasks, LLMs, or any application that needs accurate sentence boundaries.
 
     [:octicons-arrow-right-24: Learn More](sentence_splitter.md)
     
@@ -16,9 +16,9 @@ Welcome to the programmatic interface! This is where you integrate Chunklet-py's
 
     ---
 
-    Transforms plain text and diverse document formats (`.pdf`, `.docx`, `.epub`, `.eml`, `.pptx`, `.txt`, `.tex`, `.html`, `.hml`, `.md`, `.rst`, `.rtf`, `.odt`, `.csv`, and `.xlsx`) into perfectly sized, context-aware chunks with flexible composable constraints and intelligent overlap for optimal LLM and embedding performance.
+    Transforms plain text and diverse document formats (`.pdf`, `.docx`, `.epub`, `.eml`, `.pptx`, `.txt`, `.tex`, `.html`, `.hml`, `.md`, `.rst`, `.rtf`, `.odt`, `.csv`, and `.xlsx`) into sized chunks with composable constraints and overlap for LLM and embedding pipelines.
 
-    Perfect for RAG systems, document analysis, and any workflow that needs smart text segmentation with full control over chunk sizes.
+    Great for RAG systems, document analysis, or any workflow that needs chunk size control.
 
     [:octicons-arrow-right-24: Learn More](document_chunker.md)
 
@@ -26,9 +26,9 @@ Welcome to the programmatic interface! This is where you integrate Chunklet-py's
 
     ---
 
-    Intelligently chunks source code while preserving logical structure and context and maintaining code semantics across functions, classes, and modules.
+    Chunks source code while preserving logical structure and maintaining code semantics across functions, classes, and modules.
 
-    Language-agnostic and lightweight - ideal for code understanding and generation tasks, analysis, documentation, and AI model training.
+    Language-agnostic and lightweight — great for code understanding, generation, analysis, documentation, and AI model training.
 
     [:octicons-arrow-right-24: Learn More](code_chunker.md)
 
@@ -38,7 +38,7 @@ Welcome to the programmatic interface! This is where you integrate Chunklet-py's
 
     Interactive web interface for real-time chunk visualization, parameter tuning, and exploring chunking results with live feedback.
 
-    Perfect for experimenting with chunking strategies, comparing different settings, and understanding how your text gets processed.
+    Great for experimenting with chunking strategies and comparing different settings.
 
     [:octicons-arrow-right-24: Learn More](visualizer.md)
 

--- a/docs/getting-started/programmatic/sentence_splitter.md
+++ b/docs/getting-started/programmatic/sentence_splitter.md
@@ -6,7 +6,7 @@
 
 ## The Art of Precise Sentence Splitting ✂️
 
-Splitting text by periods is like trying to perform surgery with a butter knife — it barely works and makes a mess. Abbreviations get misinterpreted, sentences get cut mid-thought, and your NLP models end up confused.
+Splitting text by periods is like trying to perform surgery with a butter knife: it barely works and makes a mess. Abbreviations get misinterpreted, sentences get cut mid-thought, and your NLP models end up confused.
 
 This problem has a name: [Sentence Boundary Disambiguation](https://en.wikipedia.org/wiki/Sentence_boundary_disambiguation). That's where `SentenceSplitter` comes in.
 
@@ -21,7 +21,7 @@ The `SentenceSplitter` is a sophisticated system:
 -  **Output Refinement ✨:** Removes empty sentences and fixes punctuation.
 
 !!! note "Auto language detection requires the `[auto]` extra"
-    When you use `lang="auto"`, the splitter needs `py3langid` to detect the language of your text. This is not installed by default — install it with:
+    When you use `lang="auto"`, the splitter needs `py3langid` to detect the language of your text. This is not installed by default; install it with:
 
     ```bash
     pip install 'chunklet-py[auto]'

--- a/docs/getting-started/programmatic/sentence_splitter.md
+++ b/docs/getting-started/programmatic/sentence_splitter.md
@@ -16,7 +16,7 @@ Think of it as a skilled linguist who knows where sentences actually end. It han
 
 The `SentenceSplitter` is a sophisticated system:
 
--  **Multilingual Support 🌍:** Handles over **60** languages with intelligent detection. See the [full list](../../supported-languages.md).
+-  **Multilingual Support 🌍:** Handles over **60** languages with automatic language detection. See the [full list](../../supported-languages.md).
 -  **Reliable Fallback 🛡️:** For unsupported languages, a rule-based fallback kicks in.
 -  **Output Refinement ✨:** Removes empty sentences and fixes punctuation.
 

--- a/docs/getting-started/programmatic/visualizer.md
+++ b/docs/getting-started/programmatic/visualizer.md
@@ -142,11 +142,11 @@ Open your browser to the URL shown in the terminal output. You'll find a clean i
     - Use the metadata views to understand chunk boundaries
     - The visualizer is perfect for comparing chunking strategies side-by-side
 
-    Go experiment! The visualizer makes it easy to see exactly what your settings produce, so you can fine-tune for optimal chunking.
+    Go experiment! The visualizer makes it easy to see exactly what your settings produce, so you can fine-tune your chunks.
 
 ### Headless/REST API Usage
 
-The `Visualizer` isn't just a web interface - it also provides a complete REST API for headless chunking operations. This means you can use Chunklet's interactive features programmatically without the web UI!
+The `Visualizer` provides a complete REST API for headless chunking operations. Chunk files programmatically without the web UI!
 
 #### Available Endpoints
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,27 +22,27 @@ Dumb splitting causes problems:
 
 Smart chunking solves this by:
 
-- **Smart limits** — Respects both natural boundaries (sentences, paragraphs, sections) AND configurable limits (tokens, lines, functions)
-- **Language-aware** — Detects language automatically and applies the right rules (60+ languages supported)
-- **Context preservation** — Overlap between chunks, rich metadata (source, span, document structure)
+- **Smart limits**: respects both natural boundaries (sentences, paragraphs, sections) AND configurable limits (tokens, lines, functions)
+- **Language-aware**: detects language automatically and applies the right rules (60+ languages supported)
+- **Context preservation**: overlap between chunks, rich metadata (source, span, document structure)
 
 ## 🤔 So What's Chunklet-py Anyway? (And Why Should You Care?)
 
-**Chunklet-py** is a developer-friendly text splitting library for devs, researchers, and AI engineers. It goes way beyond basic character counting. I built this because I was tired of terrible chunking options. Chunklet-py chunks text, documents, and code into meaningful, context-aware pieces — perfect for RAG pipelines and LLM applications.
+**Chunklet-py** is a developer-friendly text splitting library for devs, researchers, and AI engineers. It goes way beyond basic character counting. I built this because I was tired of terrible chunking options. Chunklet-py chunks text, documents, and code into meaningful, context-aware pieces, perfect for RAG pipelines and LLM applications.
 
 Key features:
 
-- **Composable constraints** — Mix and match limits (sentences, tokens, sections) to get exactly the chunks you need
-- **Pluggable architecture** — Swap in custom tokenizers, sentence splitters, or processors  
-- **Rich metadata** — Every chunk comes with source references, spans, and structural info
-- **Multi-format support** — PDF, DOCX, EPUB, Markdown, HTML, LaTeX, ODT, CSV, Excel, and plain text
+- **Composable constraints**: mix and match limits (sentences, tokens, sections) to get exactly the chunks you need
+- **Pluggable architecture**: swap in custom tokenizers, sentence splitters, or processors  
+- **Rich metadata**: every chunk comes with source references, spans, and structural info
+- **Multi-format support**: PDF, DOCX, EPUB, Markdown, HTML, LaTeX, ODT, CSV, Excel, and plain text
 
 Available tools:
 
-- `SentenceSplitter` — Lightweight sentence tokenization
-- `DocumentChunker` — Natural language with semantic boundaries
-- `CodeChunker` — Language-aware code chunking
-- `ChunkVisualizer` — Interactive web-based exploration
+- `SentenceSplitter`: lightweight sentence tokenization
+- `DocumentChunker`: natural language with semantic boundaries
+- `CodeChunker`: language-aware code chunking
+- `ChunkVisualizer`: interactive web-based exploration
 
 Perfect for prepping data for LLMs, building RAG systems, or powering AI search - Chunklet-py handles tons of formats and languages.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Smart chunking solves this by:
 
 ## 🤔 So What's Chunklet-py Anyway? (And Why Should You Care?)
 
-**Chunklet-py** is a developer-friendly text splitting library designed to be the most versatile chunking solution — for devs, researchers, and AI engineers. It goes way beyond basic character counting. I built this because I was tired of terrible chunking options. Chunklet-py intelligently chunks text, documents, and code into meaningful, context-aware pieces — perfect for RAG pipelines and LLM applications.
+**Chunklet-py** is a developer-friendly text splitting library for devs, researchers, and AI engineers. It goes way beyond basic character counting. I built this because I was tired of terrible chunking options. Chunklet-py chunks text, documents, and code into meaningful, context-aware pieces — perfect for RAG pipelines and LLM applications.
 
 Key features:
 
@@ -44,21 +44,21 @@ Available tools:
 - `CodeChunker` — Language-aware code chunking
 - `ChunkVisualizer` — Interactive web-based exploration
 
-Perfect for prepping data for LLMs, building RAG systems, or powering AI search - Chunklet-py gives you the precision and flexibility you need across tons of formats and languages.
+Perfect for prepping data for LLMs, building RAG systems, or powering AI search - Chunklet-py handles tons of formats and languages.
 
 <div class="grid cards" markdown>
 
 - :material-speedometer:{ .lg .middle } __Blazingly Fast__
 
-    Leverages efficient parallel processing to chunk large volumes of content with remarkable speed.
+    Fast parallel processing for chunking large volumes of content.
 
 - :fontawesome-solid-feather:{ .lg .middle } __Featherlight Footprint__
 
-    Designed to be lightweight and memory-efficient, ensuring optimal performance without unnecessary overhead.
+    Lightweight and memory-efficient, no unnecessary overhead.
 
 - :material-database-marker-outline:{ .lg .middle } __Rich Metadata for RAG__
 
-    Enriches chunks with valuable, context-aware metadata (source, span, document properties, code AST details) crucial for advanced RAG and LLM applications.
+    Metadata for every chunk: source, span, document properties, code AST details.
 
 - :material-tune:{ .lg .middle } __Infinitely Customizable__
 
@@ -70,7 +70,7 @@ Perfect for prepping data for LLMs, building RAG systems, or powering AI search 
 
 - :material-code-tags:{ .lg .middle } __Code-Aware Intelligence__
 
-    Language-agnostic code chunking that understands and preserves the structural integrity of your source code.
+    Code chunking that preserves the structure of your source code.
 
 - :material-ruler-square:{ .lg .middle } __Precision Chunking__
 
@@ -97,7 +97,7 @@ Wondering how we compare to other chunking tools? Here's the quick comparison:
 | [Semchunk](https://github.com/isaacus-dev/semchunk) | Text-only, fast semantic splitting. Built-in tiktoken/HuggingFace support. 85% faster than alternatives. | Text |
 | [CintraAI Code Chunker](https://github.com/CintraAI/code-chunker) | Code-specific, uses `tree-sitter`. Initially supports Python, JS, CSS only. | Code |
 
-Chunklet-py is a specialized, drop-in replacement for the chunking step in any RAG pipeline. It handles text, documents, and code without heavy dependencies, while keeping your project lightweight.
+Chunklet-py is a specialized, drop-in replacement for the chunking step in any RAG pipeline. It handles text, documents, and code without heavy dependencies.
 
 ## Ready? Let's Go!
 
@@ -115,14 +115,14 @@ Curious about all the features?
 
 *   [**Supported Languages:**](supported-languages.md) See which languages Chunklet speaks fluently.
 *   [**Exceptions and Warnings:**](exceptions-and-warnings.md) Because sometimes, things go wrong. Here's what to do when they do.
-*   [**Metadata:**](getting-started/metadata.md) Understand the rich context `chunklet` attaches to your chunks.
+*   [**Metadata:**](getting-started/metadata.md) Understand the context `chunklet` attaches to your chunks.
 *   [**Troubleshooting:**](troubleshooting.md) Solutions to common issues you might encounter.
 
 ## Stay in the Loop
 
 Want to keep up with Chunklet-py's latest adventures?
 
-  *   [**What's New:**](whats-new.md) Discover all the exciting new features and improvements in Chunklet.
+  *   [**What's New:**](whats-new.md) Check out the latest features and improvements in Chunklet.
   *   [**Migration Guide:**](migration.md) Learn how to smoothly transition from previous versions to Chunklet 3.x.x.
 
  *   [**Changelog:**](https://github.com/speedyk-005/chunklet-py/blob/main/CHANGELOG.md) See what's new, what's fixed, and what's been improved in recent versions.
@@ -133,5 +133,5 @@ Want to keep up with Chunklet-py's latest adventures?
 For the behind-the-scenes info and if you're thinking of contributing:
 
  *   [**GitHub Repository:**](https://github.com/speedyk-005/chunklet-py) The main hub for all things Chunklet.
- *   [**License Information:**](https://github.com/speedyk-005/chunklet-py/blob/main/LICENSE) All the necessary bits and bobs about Chunklet-py's license.
+ *   [**License Information:**](https://github.com/speedyk-005/chunklet-py/blob/main/LICENSE) Bits and bobs about Chunklet-py's license.
  *   [**Contributing:**](https://github.com/speedyk-005/chunklet-py/blob/main/CONTRIBUTING.md) Want to help make Chunklet even better? Find out how you can contribute!                                            

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -26,7 +26,7 @@ The v2-v3 jump is small: no API renames, just a couple of removals. If you're al
 
 ### Custom processor registry is now instance-based
 
-In v2, custom processors lived on a **global** `custom_processor_registry` singleton shared across your whole app. In v3 that global is gone — you now create a `CustomProcessorRegistry()` yourself and pass it to a `DocumentChunker` via `processor_registry`. Each registry is independent, so registrations are scoped to the chunker you attach it to.
+In v2, custom processors lived on a **global** `custom_processor_registry` singleton shared across your whole app. In v3 that global is gone, you now create a `CustomProcessorRegistry()` yourself and pass it to a `DocumentChunker` via `processor_registry`. Each registry is independent, so registrations are scoped to the chunker you attach it to.
 
 **Fix:**
 
@@ -76,14 +76,14 @@ If you were already calling the `chunk_text`/`chunk_texts`/`split_text` methods,
 
 ### `lang="auto"` is no longer the default
 
-In v2, `lang` defaulted to `"auto"` and `py3langid` was a hard dependency — it was always installed. In v3, `lang` is required (no default), and `py3langid` is now an optional extra called `[auto]`.
+In v2, `lang` defaulted to `"auto"` and `py3langid` was a hard dependency; it was always installed. In v3, `lang` is required (no default), and `py3langid` is now an optional extra called `[auto]`.
 
 If you were relying on automatic language detection, you need to:
 
 1. Pass `lang="auto"` explicitly (it's no longer implicit).
 2. Install the extra: `pip install 'chunklet-py[auto]'`
 
-If you only ever used specific language codes like `lang="en"`, you don't need the extra — the default install is enough.
+If you only ever used specific language codes like `lang="en"`, you don't need the extra; the default install is enough.
 
 === "Before (v2.x.x)"
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -10,9 +10,9 @@ We use [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) codes (those handy t
 
 ## The All-Stars: Languages Where Chunklet-py Truly Shines ⭐
 
-Here's where we bring out the big guns. These languages have dedicated, high-quality splitters — think of them as the VIP section of our language support. If your language is here, you're in good hands.
+Here's where we bring out the big guns. These languages have dedicated, high-quality splitters, think of them as the VIP section of our language support. If your language is here, you're in good hands.
 
-And if it's not? No worries — the [Fallback Splitter](#the-universal-translator-fallback-splitter) at the bottom of this page has your back.
+And if it's not? No worries, the [Fallback Splitter](#the-universal-translator-fallback-splitter) at the bottom of this page has your back.
 
 Let me introduce you to the libraries making this magic happen:
 
@@ -82,12 +82,12 @@ The [`Indic NLP Library`](https://github.com/anoopkunchukuttan/indic_nlp_library
 
 ### The Wildcard: `Sentencex`
 
-[`Sentencex`](https://github.com/wikimedia/sentencex) from Wikimedia adds even more languages to the mix. It's a bit more relaxed about things — uses fallbacks when it doesn't have a perfect match for your language.
+[`Sentencex`](https://github.com/wikimedia/sentencex) from Wikimedia adds even more languages to the mix. It's a bit more relaxed about things, it uses fallbacks when it doesn't have a perfect match for your language.
 
 !!! tip "Wait, what's a fallback?"
-    Good question! If `Sentencex` doesn't have a perfect splitter for your language, it falls back to a similar one. Like using Spanish rules for Galician — close enough, usually gets the job done.
+    Good question! If `Sentencex` doesn't have a perfect splitter for your language, it falls back to a similar one. Like using Spanish rules for Galician: close enough, usually gets the job done.
 
-    I've filtered the list below to only show languages that are actually useful and reliable. No point showing you 200 languages if half of them are just "eh, good enough" — right?
+    I've filtered the list below to only show languages that are actually useful and reliable. No point showing you 200 languages if half of them are just "eh, good enough", right?
 
 | Language Code | Language Name | Flag |
 |:--------------|:--------------|:----:|
@@ -111,7 +111,7 @@ The [`Indic NLP Library`](https://github.com/anoopkunchukuttan/indic_nlp_library
 
 ## The Universal Translator: Fallback Splitter 🔄
 
-So your language isn't on the list? That's okay — this is where things get interesting.
+So your language isn't on the list? That's okay, this is where things get interesting.
 
 The **Fallback Splitter** is my "when in doubt" solution. It's a rule-based regex splitter that takes a reasonable shot at sentence segmentation for... well, anything. Is it as smart as the dedicated libraries above? Nope. But it'll work when you need it to.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,19 +61,19 @@ Things break. Here's how to fix them.
     **Fix:**
 
     - Hard refresh: `Ctrl+Shift+R` (Windows/Linux) or `Cmd+Shift+R` (Mac)
-    - Or just open incognito — caches don't follow you there
+    - Or just open incognito, caches don't follow you there
 
 ## Something Broke or Warned
 
 ??? question "Something threw an exception. Now what?"
 
-    First: actually read the error message. We know, we know — "just read the error" sounds obvious, but sometimes it actually tells you what's wrong.
+    First: actually read the error message. We know, we know, "just read the error" sounds obvious, but sometimes it actually tells you what's wrong.
     
-    If it's a warning, you're probably fine — just a heads up. If it's an exception, something actually broke.
+    If it's a warning, you're probably fine, just a heads up. If it's an exception, something actually broke.
     
     **What to do:**
     
-    1. **Read the message** — it usually tells you what's up
-    2. **Check [exceptions-and-warnings.md](./exceptions-and-warnings.md)** — we explain what each one means
-    3. **Check [What's New](./whats-new.md)** — breaking changes and new stuff live there
-    4. **Open an issue** — if it's genuinely broken and not covered, let us know. But check first.
+    1. **Read the message**: it usually tells you what's up
+    2. **Check [exceptions-and-warnings.md](./exceptions-and-warnings.md)**: we explain what each one means
+    3. **Check [What's New](./whats-new.md)**: breaking changes and new stuff live there
+    4. **Open an issue**: if it's genuinely broken and not covered, let us know. But check first.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -11,7 +11,7 @@
 
 ### 🐛 EML Metadata, Actually Complete
 
-PR from [@AkshatSharma25](https://github.com/AkshatSharma25) — the EML processor was quietly dropping header fields (subject, from, to, cc, date) and only grabbing the body. Fixed. All fields captured now.
+PR from [@AkshatSharma25](https://github.com/AkshatSharma25): the EML processor was quietly dropping header fields (subject, from, to, cc, date) and only grabbing the body. Fixed. All fields captured now.
 
 ---
 
@@ -49,13 +49,13 @@ We swapped `pysbd` and `sentsplit` for [`yasbd-lib`](https://github.com/speedyk-
 
 We ditched the external `dotdict3` dependency and vendored the code in-tree. Now our `DotDict` has all the serialization methods you expect from the old python-box days:
 
-- **`to_dict()`** — recursive conversion back to plain dicts/lists
-- **`to_json()`** — serialize to JSON string or file
-- **`to_yaml()`** — YAML, obviously (needs `pyyaml`)
-- **`to_toml()`** — TOML support (needs `toml`)
-- **`to_msgpack()`** — MessagePack binary format (needs `msgpack`)
+- **`to_dict()`**: recursive conversion back to plain dicts/lists
+- **`to_json()`**: serialize to JSON string or file
+- **`to_yaml()`**: YAML, obviously (needs `pyyaml`)
+- **`to_toml()`**: TOML support (needs `toml`)
+- **`to_msgpack()`**: MessagePack binary format (needs `msgpack`)
 
-The CLI `--metadata` flag no longer crashes — `.to_dict()` actually exists now. 2.3x faster than python-box's `to_dict()` too, since we're not dragging in all of Box's feature creep.
+The CLI `--metadata` flag no longer crashes: `.to_dict()` actually exists now. 2.3x faster than python-box's `to_dict()` too, since we're not dragging in all of Box's feature creep.
 
 ### 🔧 The Boring Stuff
 
@@ -68,7 +68,7 @@ The CLI `--metadata` flag no longer crashes — `.to_dict()` actually exists now
 
 ### 🤖 Android Detection, Fixed (Kinda)
 
-v2.3.0 shipped with `platform_system` markers to detect Android. The problem? Android reports as `'Linux'`, not `'Android'` — so literally nobody was getting the right `sentencex` version. Fixed now with `sys_platform` + `platform_machine` markers. Downside: ARM Linux (Raspberry Pi, etc.) also gets the legacy `sentencex<=0.6.1` without Rust bindings. Temporary, we swear.
+v2.3.0 shipped with `platform_system` markers to detect Android. The problem? Android reports as `'Linux'`, not `'Android'`, so literally nobody was getting the right `sentencex` version. Fixed now with `sys_platform` + `platform_machine` markers. Downside: ARM Linux (Raspberry Pi, etc.) also gets the legacy `sentencex<=0.6.1` without Rust bindings. Temporary, we swear.
 
 ### 🐛 DotDict TypeError Fixed
 
@@ -82,28 +82,28 @@ Using `DotDict()` without arguments threw `TypeError` on `dotdict3 < 1.4.2`. Now
 
 The universal fallback splitter finally learned some new tricks:
 
-- **Non-Latin scripts** — Arabic, Chinese, and friends now get treated right
-- **Quoted text and parens** — "this (and this)" stay together as one sentence
-- **Numbered lists** — 1. 2. 3. now behave instead of getting split apart
+- **Non-Latin scripts**: Arabic, Chinese, and friends now get treated right
+- **Quoted text and parens**: "this (and this)" stay together as one sentence
+- **Numbered lists**: 1. 2. 3. now behave instead of getting split apart
 
 ### 📄 Document Chunker Improvements
 
-- Better markdown heading detection — we finally read your headers right
+- Better markdown heading detection: we finally read your headers right
 
 ### 🎨 Visualizer Gets Sleeker
 
-Now serving both JSON and MessagePack — because one format was never enough:
+Now serving both JSON and MessagePack, because one format was never enough:
 
 - Browser visualizer requests MessagePack automatically for performance (~30-50%)
 - Programmatic clients can choose: JSON (default) or MessagePack (opt-in via `Accept: application/msgpack` header)
-- MessagePack encoding — because we care about your bandwidth
+- MessagePack encoding: because we care about your bandwidth
 
 ### 🐛 The Fixes
 
-- **pkg_resources** — finally fixed that annoying ModuleNotFoundError (long story)
-- **Registration** — no more TypeError with `functools.partial` when registering custom splitters
-- **Auto-lang** — stopped spamming you with repeated warnings when `lang='auto'`
-- **Code output** — methods now appear under their class, not "global" (we know, it was annoying)
+- **pkg_resources**: finally fixed that annoying ModuleNotFoundError (long story)
+- **Registration**: no more TypeError with `functools.partial` when registering custom splitters
+- **Auto-lang**: stopped spamming you with repeated warnings when `lang='auto'`
+- **Code output**: methods now appear under their class, not "global" (we know, it was annoying)
 
 ### 🔧 The Boring Stuff
 
@@ -117,18 +117,18 @@ Now serving both JSON and MessagePack — because one format was never enough:
 
 ### ✨ Simpler Chunking API
 
-We renamed some methods. Yes, we're those people who rename things. But honestly, the old names were confusing — even to us:
+We renamed some methods. Yes, we're those people who rename things. But honestly, the old names were confusing even to us:
 
-- `chunk_text()` — chunk a string
-- `chunk_file()` — chunk a file directly  
-- `chunk_texts()` — batch strings
-- `chunk_files()` — batch files
+- `chunk_text()`: chunk a string
+- `chunk_file()`: chunk a file directly  
+- `chunk_texts()`: batch strings
+- `chunk_files()`: batch files
 
-The old `chunk` and `batch_chunk` still work. They'll whine at you with a deprecation warning. Deal with it or migrate — your choice.
+The old `chunk` and `batch_chunk` still work. They'll whine at you with a deprecation warning. Deal with it or migrate; your choice.
 
 ### 🔗 PlainTextChunker Got Absorbed
 
-`PlainTextChunker` is now part of `DocumentChunker`. We know — having two chunkers was weird. Just use `chunk_text()` or `chunk_texts()` like a normal person. The old import still works, technically, with a deprecation warning.
+`PlainTextChunker` is now part of `DocumentChunker`. We know, having two chunkers was weird. Just use `chunk_text()` or `chunk_texts()` like a normal person. The old import still works, technically, with a deprecation warning.
 
 ### ✂️ SentenceSplitter Now Does `split_text()`
 
@@ -138,10 +138,10 @@ The old `chunk` and `batch_chunk` still work. They'll whine at you with a deprec
 
 The chunk visualizer finally got some love:
 
-- **Fullscreen mode** — for when you want to pretend you're doing something important
-- **3-row layout** — less cluttered, more clickable
-- **Smoother hovers** — no more seizure-inducing animations
-- **Smarter buttons** — they stay enabled because, honestly, disabling them was stupid
+- **Fullscreen mode**: for when you want to pretend you're doing something important
+- **3-row layout**: less cluttered, more clickable
+- **Smoother hovers**: no more seizure-inducing animations
+- **Smarter buttons**: they stay enabled because, honestly, disabling them was stupid
 
 ### ⌨️ Shorter CLI Flags
 
@@ -157,17 +157,17 @@ You're welcome.
 
 Code chunking got slightly less terrible:
 
-- **Cleaner output** — fixed weird artifacts in chunks from comment handling (we know, it was annoying)
-- **More languages** — Forth, PHP 8 attributes, VB.NET, ColdFusion, and Pascal. Yes, really.
-- **String protection** — multi-line strings and triple-quotes won't get mangled anymore
+- **Cleaner output**: fixed weird artifacts in chunks from comment handling (we know, it was annoying)
+- **More languages**: Forth, PHP 8 attributes, VB.NET, ColdFusion, and Pascal. Yes, really.
+- **String protection**: multi-line strings and triple-quotes won't get mangled anymore
 
 ### 🔧 The Boring But Necessary Stuff
 
-- **Tokenizer timeout** — new `--tokenizer-timeout` / `-t` flag so custom tokenizers don't hang forever
-- **Direct imports** — `from chunklet import DocumentChunker` now works without making things slow
-- **Fewer crashes** — fixed dependency issues with `setuptools<81` in CI (sentsplit and pkg_resources, long story)
-- **Global registries** — `custom_splitter_registry` and `custom_processor_registry` exist now
-- **Error messages** — slightly less cryptic when things explode
+- **Tokenizer timeout**: new `--tokenizer-timeout` / `-t` flag so custom tokenizers don't hang forever
+- **Direct imports**: `from chunklet import DocumentChunker` now works without making things slow
+- **Fewer crashes**: fixed dependency issues with `setuptools<81` in CI (sentsplit and pkg_resources, long story)
+- **Global registries**: `custom_splitter_registry` and `custom_processor_registry` exist now
+- **Error messages**: slightly less cryptic when things explode
 
 ---
 
@@ -191,7 +191,7 @@ We built an actual UI. Because sometimes you want to click buttons instead of wr
 
 ### 📁 More File Formats
 
-ODT, CSV, and Excel (.xlsx) — added in this release. Because apparently plain text wasn't enough for some people.
+ODT, CSV, and Excel (.xlsx), added in this release. Because apparently plain text wasn't enough for some people.
 
 ---
 
@@ -201,12 +201,12 @@ ODT, CSV, and Excel (.xlsx) — added in this release. Because apparently plain 
 
 We rewrote the whole thing. You're welcome? Here's what changed:
 
-- **🗃 New classes** — PlainTextChunker, DocumentChunker, CodeChunker
-- **🌍 50+ languages** — because the world has more than English
-- **📄 Document formats** — PDF, DOCX, EPUB, HTML, etc.
-- **💻 Code understanding** — actual code chunking, not just "split by lines like a savage"
-- **🎯 New constraints** — `max_section_breaks` and `max_lines` for finer control
-- **⚡ Memory efficient batch** — generators in batch methods so your RAM doesn't cry
+- **🗃 New classes**: PlainTextChunker, DocumentChunker, CodeChunker
+- **🌍 50+ languages**: because the world has more than English
+- **📄 Document formats**: PDF, DOCX, EPUB, HTML, etc.
+- **💻 Code understanding**: actual code chunking, not just "split by lines like a savage"
+- **🎯 New constraints**: `max_section_breaks` and `max_lines` for finer control
+- **⚡ Memory efficient batch**: generators in batch methods so your RAM doesn't cry
 
 ---
 


### PR DESCRIPTION
## Summary

A prose pass over the README and the docs site. Before, it read like marketing copy written by an LLM: superlative filler, forced alliterative triples, em dashes doing all the punctuation work. This tightens the language while keeping the voice that makes the docs actually fun to read.

## What Changed

- Trimmed promotional filler ("remarkable speed", "unlocks additional functionalities", "all the secrets") and swapped puffed claims for concrete descriptions
- Straightened feature tables in the README and docs landing page so each row says something real
- Cut em-dash clumps and redundant hand-waving in CLI and metadata guides
- Kept the charm: the wedding-cake joke, "choose your own adventure for data", "Easy peasy!", "your RAM will thank you later", so the personality stays, only the slop goes

## Example

Before: "The `chunk` command is where the real magic happens!"
After: "The `chunk` command is where the chunking happens!"

But also before: "Think of metadata as your chunk's detailed biography - the who, what, when, and where"
After: still there, verbatim. That line was fine.